### PR TITLE
スクショがnullならデフォルトをセットする

### DIFF
--- a/Assets/_MyAssets/Scripts/Runtime/UI/Title/SaveSlot/Select/ViewConstructor.cs
+++ b/Assets/_MyAssets/Scripts/Runtime/UI/Title/SaveSlot/Select/ViewConstructor.cs
@@ -70,7 +70,7 @@ namespace MyScripts.Runtime.UI.Title.SaveSlot.Select
                     }
                     float leftRatio = 100.0f * leftCount / Constants.SOSSignCount;
 
-                    slotInfos[i].ThumbnailImage.sprite = cachedThumbnailSprites[i];
+                    slotInfos[i].ThumbnailImage.sprite = (cachedThumbnailSprites[i] ? cachedThumbnailSprites[i] : defaultThumbnailSprite);
                     slotInfos[i].ProgressText.SetTextFormat("{0:F2}%", leftRatio);
                     slotInfos[i].DateText.text = ZString.Format("{0:yyyy-MM-dd}\n{0:HH:mm}", slotData.GetLastSavedAt());
                 }


### PR DESCRIPTION
## 概要
- スクショをロードできなかった時はキャッシュがnullになるが、その場合もデフォルトスプライトが使われるようにした
