### PR TITLE
ダウンロード自体のタイムアウト時間を設定

### DIFF
--- a/Assets/_MyAssets/Scripts/Common/FileDownloader.cs
+++ b/Assets/_MyAssets/Scripts/Common/FileDownloader.cs
@@ -24,11 +24,12 @@ internal static class FileDownloader
     /// <param name="saveName">ローカルに保存する名前. 拡張子は含めない</param>
     /// <param name="extension">拡張子. URLの文字列からは厳密に判定できないので、明示的に指定する</param>
     /// <param name="ct">キャンセレーショントークン</param>
-    /// <param name="timeoutSeconds">Webリクエストのタイムアウト時間 (秒)</param>
+    /// <param name="webRequestTimeoutSeconds">Webリクエストのタイムアウト時間 (秒)</param>
+    /// <param name="downloadTimeoutSeconds">ファイルダウンロード自体のタイムアウト時間 (秒)<br/>回線が悪いだけの場合、Webリクエストは失敗しない懸念があるので、別途この条件でタイムアウトさせる</param>
     /// <returns>ダウンロード成功ならば (true, ローカル保存パス)、失敗ならば (false, "") を返す</returns>
     internal static async UniTask<(bool Success, string Path)> DownloadAsync(
-        string url, string saveName, Extension extension,
-        Ct ct, int timeoutSeconds = 5
+        string url, string saveName, Extension extension, Ct ct,
+        int webRequestTimeoutSeconds = 5, int downloadTimeoutSeconds = 10
     )
     {
         ct.ThrowIfCancellationRequested();
@@ -74,12 +75,34 @@ internal static class FileDownloader
         {
             // ダウンロードに失敗した場合、途中までのファイルを削除する
             request.downloadHandler = new DownloadHandlerFile(savePath) { removeFileOnAbort = true };
-            request.timeout = timeoutSeconds;
+            request.timeout = webRequestTimeoutSeconds;
         }
 
         $"Starting download from URL: {url}".Print();
 
-        await request.SendWebRequest().ToUniTask(cancellationToken: ct);
+        try
+        {
+            // Cts を合成する (外部からのキャンセル要求 or ダウンロードタイムアウト)
+            using Cts downloadTimeoutCts = new(TimeSpan.FromSeconds(downloadTimeoutSeconds));
+            using Cts ctsReal = Cts.CreateLinkedTokenSource(ct, downloadTimeoutCts.Token);
+
+            await request.SendWebRequest().ToUniTask(cancellationToken: ctsReal.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            // 外部からのキャンセル要求
+            if (ct.IsCancellationRequested)
+            {
+                $"Download canceled by external request.".Print(LogSettings.Warning);
+            }
+            // ダウンロードタイムアウト
+            else
+            {
+                $"Download timed out after {downloadTimeoutSeconds} seconds.".Print(LogSettings.Warning);
+            }
+
+            return (false, "");
+        }
 
         // ダウンロード失敗
         if (request.result != UnityWebRequest.Result.Success)


### PR DESCRIPTION
## 概要
回線が悪いだけの場合、Webリクエストが失敗してくれない懸念が起こった。
ダウンロード自体のタイムアウト（今は10秒に設定）を設け、その時間を超過しても失敗するようにした。