### PR TITLE
VSyncをオフに戻す

### DIFF
--- a/Assets/_MyAssets/Scripts/Common/Initializer.cs
+++ b/Assets/_MyAssets/Scripts/Common/Initializer.cs
@@ -6,7 +6,7 @@ internal static class Initializer
     private static void Init()
     {
         Screen.SetResolution(1920, 1080, true);
-        QualitySettings.vSyncCount = 1;
+        QualitySettings.vSyncCount = 0;
         Application.targetFrameRate = 60;
 
         ConnectSteamAsync().Forget();


### PR DESCRIPTION
## 概要
VSyncオンだと、60FPS以上で処理が間に合わなかったので、やっぱりオフに戻す
