### PR TITLE
特定方向の慣性ジャンプの停止

### DIFF
--- a/Assets/_MyAssets/Scripts/Runtime/PlayerController.cs
+++ b/Assets/_MyAssets/Scripts/Runtime/PlayerController.cs
@@ -227,8 +227,16 @@ namespace MyScripts.Runtime
 			// 陸のアニマを取得していないとダメ
 			if (animalLeaveInvoker.PossessingCharacterType != CharacterType.Land) return;
 
-			// 水平方向にある程度の速度が必要
-			if (realHorizontalVelocity.sqrMagnitude < param.InertiaJumpLimitSpeedSqr) return;
+            Vector2 moveDirectionXZ = new Vector2(realHorizontalVelocity.x, realHorizontalVelocity.z).normalized;
+            {
+                Vector2 playerForwardXZ = new Vector2(transform.forward.x, transform.forward.z).normalized;
+                float threshold = Mathf.Cos(param.InertiaJumpDirectionAllowedAngle * 0.5f * Mathf.Deg2Rad);
+                // "前方"に向かって移動している必要がある
+                if (Vector2.Dot(playerForwardXZ, moveDirectionXZ) < threshold) return;
+            }
+
+            // 水平方向にある程度の速度が必要
+            if (realHorizontalVelocity.sqrMagnitude < param.InertiaJumpLimitSpeedSqr) return;
 
 			// ダッシュしていないならダメ
 			if (!isSprinting) return;
@@ -248,17 +256,11 @@ namespace MyScripts.Runtime
 
 			isDoingInertiaJump = true;
 
-			Vector2 moveDirectionXZ = new Vector2(realHorizontalVelocity.x, realHorizontalVelocity.z).normalized;
 			Vector3 velocity = new(
 				moveDirectionXZ.x * param.InertiaJumpVelocity.x,
 				param.InertiaJumpVelocity.y,
 				moveDirectionXZ.y * param.InertiaJumpVelocity.z
 			);
-			Vector2 bodyDirectionXZ = new Vector2(transform.forward.x, transform.forward.z).normalized;
-
-			//体の向きと移動方向の角度が60度より大きいとダメ
-			if (Vector2.Dot(moveDirectionXZ, bodyDirectionXZ) < param.InertiaJumpRange) return;
-
 			ApplyOuterVelocity(velocity);
 
 			soundPlayer.LetPlay(SPlayerControlSound.Action.InertiaJump);

--- a/Assets/_MyAssets/Scripts/SO/InGame/SPlayerControl.cs
+++ b/Assets/_MyAssets/Scripts/SO/InGame/SPlayerControl.cs
@@ -61,11 +61,11 @@
         [SerializeField, Tooltip("加算する速度(プレイヤーから見た相対ベクトル)")] private Vector3 inertiaJumpVelocity = new(30.0f, 15.0f, 30.0f);
         [SerializeField, Tooltip("必要な水平速度 の平方")] private float inertiaJumpLimitSpeedSqr = 100.0f;
         [SerializeField] private float inertiaJumpCoolTime = 0.2f;
-        [SerializeField, Tooltip("慣性ジャンプが行える方向の範囲（体の向きと移動方向の内積）")] private float inertiaJumpRange = 0.5f;
+        [SerializeField, Tooltip("前方に対する視野角と同じ意味の開き角。この角度の範囲内の移動方向なら慣性ジャンプ可能(度)")] private float inertiaJumpDirectionAllowedAngle = 120.0f;
         internal Vector3 InertiaJumpVelocity => inertiaJumpVelocity;
         internal float InertiaJumpLimitSpeedSqr => inertiaJumpLimitSpeedSqr;
         internal float InertiaJumpCoolTime => inertiaJumpCoolTime;
-        internal float InertiaJumpRange => inertiaJumpRange;
+        internal float InertiaJumpDirectionAllowedAngle => inertiaJumpDirectionAllowedAngle;
 
         [Space(10)]
 


### PR DESCRIPTION
## 概要
アニマ取得時の慣性ジャンプの発生条件に体の向きと移動方向からなる角度を追加

## 行ったこと
- 慣性ジャンプ時、正面ベクトル・移動方向ベクトルのなす角が ○ 度以下でないとダメなようにした
- 「なす角 ○ 度」をパラメータ化

## 補足情報
[バグ報告]
データを選択し、シーンを移動した際にチュートリアルが出る前にF8などのFキーを押すとエラーが発生しチュートリアルムービーが出なくなる

## プレイ動画
長くて送れませんでした......