### PR TITLE
アニマ取得時のプレイヤーの加速条件を追加

### DIFF
--- a/Assets/_MyAssets/Scripts/Runtime/PlayerController.cs
+++ b/Assets/_MyAssets/Scripts/Runtime/PlayerController.cs
@@ -333,23 +333,19 @@ namespace MyScripts.Runtime
             // 特定のアニマを取得している場合、対応するエリア内で移動速度が速くなる
             if (animalLeaveInvoker.PossessingCharacterType == CharacterType.Sea)
             {
-                if (isGrounded || IsInsideOfArea(SWalkSound.Surface.Water, becameNotGroundedPosition))
+                if ((isGrounded && IsInsideOfArea(SWalkSound.Surface.Water, controller.transform.position)) ||
+                    (!isGrounded && IsInsideOfArea(SWalkSound.Surface.Water, becameGroundedPosition)))
                 {
-                    if (IsInsideOfArea(SWalkSound.Surface.Water, controller.transform.position))
-                    {
-                        targetSpeed *= param.MoveSpeedMultiplierWhenHasSea;
-                    }
+                    targetSpeed *= param.MoveSpeedMultiplierWhenHasSea;
                 }
             }
             else if (animalLeaveInvoker.PossessingCharacterType == CharacterType.Land)
             {
                 // Water 以外の場所を陸上とみなす
-                if (isGrounded || !IsInsideOfArea(SWalkSound.Surface.Water, becameNotGroundedPosition))
+                if ((isGrounded && !IsInsideOfArea(SWalkSound.Surface.Water, controller.transform.position)) ||
+                    (!isGrounded && !IsInsideOfArea(SWalkSound.Surface.Water, becameGroundedPosition)))
                 {
-                    if (!IsInsideOfArea(SWalkSound.Surface.Water, controller.transform.position))
-                    {
-                        targetSpeed *= param.MoveSpeedMultiplierWhenHasLand;
-                    }
+                    targetSpeed *= param.MoveSpeedMultiplierWhenHasLand;
                 }
             }
 


### PR DESCRIPTION
## 概要
プレイヤーが海または陸のアニマを取得している際、加速条件に対象のエリア内かだけでなくプレイヤーが地面に接地しているかを追加

## 行ったこと
・加速条件の中に既存のbool型の変数isGroundedを追加

## 行わなかったこと
空中に飛び出した時は加速しないが、地上からジャンプした際は加速するといった場合分けの処理は実装していない
（要相談）

## 補足情報
[バグ報告]
岩のコライダーがズレている箇所がいくつか存在し、結果移動できない箇所や空中で五段ジャンプしているように見える箇所や空中から木に登れてしまう箇所が存在している
例としては座標の大体（36.87,-17.02,439.96)から(-8.29,-10.49,474.19)の範囲で
Y軸が-156.9の方向に移動しようとすると（恐らく)近くの岩のコライダーがずれて見えない壁のようになっています
以下ズレて宙に浮いているように見えたときの画像
<img width="1917" height="1029" alt="スクリーンショット 2026-02-12 153559" src="https://github.com/user-attachments/assets/b0f9a08d-baea-4260-83fc-beaa7248943f" />
