### PR TITLE
「CustomToolbar」の不要な項目をオフにする

### DIFF
--- a/Assets/Settings/CustomToolbar/CustomToolbarSettings.asset
+++ b/Assets/Settings/CustomToolbar/CustomToolbarSettings.asset
@@ -19,7 +19,7 @@ MonoBehaviour:
     - name: OpalStudio.CustomToolbar.Editor.ToolbarElements.ToolbarGitStatus, CustomToolbar,
         Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
       isEnabled: 1
-    isEnabled: 1
+    isEnabled: 0
   - groupName: Utilities
     side: 0
     elements:
@@ -37,7 +37,7 @@ MonoBehaviour:
       isEnabled: 1
     - name: OpalStudio.CustomToolbar.Editor.ToolbarElements.SceneBookmarks.ToolbarSceneBookmarks,
         CustomToolbar, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-      isEnabled: 1
+      isEnabled: 0
     isEnabled: 1
   - groupName: Scenes
     side: 0
@@ -77,7 +77,7 @@ MonoBehaviour:
     - name: OpalStudio.CustomToolbar.Editor.ToolbarElements.ToolbarReserializeAll,
         CustomToolbar, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
       isEnabled: 1
-    isEnabled: 1
+    isEnabled: 0
   - groupName: Toolbox
     side: 1
     elements:
@@ -87,5 +87,5 @@ MonoBehaviour:
     - name: OpalStudio.CustomToolbar.Editor.ToolbarElements.Favorites.ToolbarFavorites,
         CustomToolbar, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
       isEnabled: 1
-    isEnabled: 1
+    isEnabled: 0
   toolboxShortcuts: []

--- a/Qualia.slnx
+++ b/Qualia.slnx
@@ -3,9 +3,11 @@
   <Project Path="ZString.csproj" />
   <Project Path="foriver4725.Border.csproj" />
   <Project Path="MyScripts.EditorExtension.Private.csproj" />
+  <Project Path="CustomToolbar.csproj" />
   <Project Path="Assembly-CSharp.csproj" />
   <Project Path="foriver4725.ScriptsValidator.csproj" />
   <Project Path="MyScripts.Steam.csproj" />
   <Project Path="MyScripts.EditorExtension.Public.csproj" />
+  <Project Path="Assembly-CSharp-Editor.csproj" />
   <Project Path="foriver4725.Benchmarker.csproj" />
 </Solution>


### PR DESCRIPTION
## 概要
横に長すぎて被ってしまったので、使うものだけオンにして残した
プロジェクト設定が変更されたので、Gitの差分が発生

<img width="1620" height="179" alt="image" src="https://github.com/user-attachments/assets/81291ac3-43d2-4355-9433-88b49a80217c" />
