### PR TITLE
カットシーン再生システムの修正

### DIFF
--- a/Assets/_MyAssets/Scenes/Main.unity
+++ b/Assets/_MyAssets/Scenes/Main.unity
@@ -2536,6 +2536,7 @@ MonoBehaviour:
     bgFadeDurationSeconds: 0.5
     stepFadeDurationSeconds: 1
   pauseInvoker: {fileID: 196192313}
+  storyMovie: {fileID: 11400000, guid: a3c3ad9930d7e894cb66aa5d272f446b, type: 2}
 --- !u!1 &685558487
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/_MyAssets/Scripts/Runtime/CutScenePlayer.cs
+++ b/Assets/_MyAssets/Scripts/Runtime/CutScenePlayer.cs
@@ -8,7 +8,6 @@ namespace MyScripts.Runtime
         [SerializeField] private Image bg;
         [SerializeField] private RawImage rawImage;
         [SerializeField] private VideoPlayer videoPlayer;
-        [SerializeField] private VideoClip videoClip;
 
         internal bool IsPlaying { get; private set; } = false;
 
@@ -19,39 +18,32 @@ namespace MyScripts.Runtime
         {
             rawImage.enabled = false;
             videoPlayer.source = VideoSource.VideoClip;
-            videoPlayer.clip = videoClip;
 
             bgAlphaMax = bg.color.a;
             SetBgAlpha(0.0f);
             bg.enabled = false;
 
             videoPlayer.prepareCompleted += OnPrepareCompleted;
-            videoPlayer.started          += OnStarted;
+            videoPlayer.started += OnStarted;
             videoPlayer.loopPointReached += OnLoopPointReached;
-            videoPlayer.errorReceived    += OnErrorReceived;
+            videoPlayer.errorReceived += OnErrorReceived;
         }
 
         private void OnDestroy()
         {
             videoPlayer.prepareCompleted -= OnPrepareCompleted;
-            videoPlayer.started          -= OnStarted;
+            videoPlayer.started -= OnStarted;
             videoPlayer.loopPointReached -= OnLoopPointReached;
-            videoPlayer.errorReceived    -= OnErrorReceived;
+            videoPlayer.errorReceived -= OnErrorReceived;
         }
 
-        public async UniTask PlayAsync(Ct ct)
+        public async UniTask PlayAsync(VideoClip videoClip, Ct ct)
         {
             ct.ThrowIfCancellationRequested();
 
             if (IsPlaying)
             {
                 "既にカットシーンが再生中です。".Print(LogSettings.Warning);
-                return;
-            }
-
-            if (videoClip == null)
-            {
-                "VideoClip が設定されていません。".Print(LogSettings.Error);
                 return;
             }
 
@@ -71,7 +63,7 @@ namespace MyScripts.Runtime
 
             try
             {
-                await UniTask.WaitUntil(() => !IsPlaying, cancellationToken: ct);
+                await UniTask.WaitUntil(this, static self => !self.IsPlaying, cancellationToken: ct);
             }
             catch (OperationCanceledException)
             {
@@ -94,7 +86,7 @@ namespace MyScripts.Runtime
         #region 内部デリゲート
 
         private void OnPrepareCompleted(VideoPlayer _) => OnPrepareCompletedInternal();
-        private void OnStarted(VideoPlayer _)          => OnStartedInternal();
+        private void OnStarted(VideoPlayer _) => OnStartedInternal();
         private void OnLoopPointReached(VideoPlayer _) => OnLoopPointReachedInternal();
         private void OnErrorReceived(VideoPlayer _, string message) => OnErrorReceivedInternal(message);
 
@@ -142,9 +134,9 @@ namespace MyScripts.Runtime
             bg.enabled = true;
 
             await LMotion.Create(0.0f, bgAlphaMax, duration)
-                        .WithEase(Ease.OutQuad)
-                        .Bind(SetBgAlpha)
-                        .ToUniTask(cancellationToken: ct);
+                .WithEase(Ease.OutQuad)
+                .Bind(SetBgAlpha)
+                .ToUniTask(cancellationToken: ct);
         }
 
         private async UniTaskVoid OnEndPlayAsync(float duration, Ct ct)
@@ -154,9 +146,9 @@ namespace MyScripts.Runtime
             SetBgAlpha(bgAlphaMax);
 
             await LMotion.Create(bgAlphaMax, 0.0f, duration)
-                        .WithEase(Ease.InQuad)
-                        .Bind(SetBgAlpha)
-                        .ToUniTask(cancellationToken: ct);
+                .WithEase(Ease.InQuad)
+                .Bind(SetBgAlpha)
+                .ToUniTask(cancellationToken: ct);
 
             bg.enabled = false;
         }

--- a/Assets/_MyAssets/Scripts/Runtime/CutScenePlayer.cs
+++ b/Assets/_MyAssets/Scripts/Runtime/CutScenePlayer.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine.Video;
+using UnityEngine.Video;
 
 namespace MyScripts.Runtime
 {
@@ -8,92 +8,85 @@ namespace MyScripts.Runtime
         [SerializeField] private Image bg;
         [SerializeField] private RawImage rawImage;
         [SerializeField] private VideoPlayer videoPlayer;
+        [SerializeField] private VideoClip videoClip;
 
-        private bool isPlaying = false;
-        // 最後に再生したカットシーン種別 (再生終了後も保持)
-        private string currentPlayingId; // 動画のみが入る想定
+        internal bool IsPlaying { get; private set; } = false;
 
         // Awake で初期化
         private float bgAlphaMax;
 
-        internal bool IsPlaying => isPlaying;
-
         private void Awake()
         {
             rawImage.enabled = false;
-            videoPlayer.source = VideoSource.Url;
+            videoPlayer.source = VideoSource.VideoClip;
+            videoPlayer.clip = videoClip;
 
             bgAlphaMax = bg.color.a;
             SetBgAlpha(0.0f);
             bg.enabled = false;
 
             videoPlayer.prepareCompleted += OnPrepareCompleted;
-            videoPlayer.started += OnStarted;
+            videoPlayer.started          += OnStarted;
             videoPlayer.loopPointReached += OnLoopPointReached;
+            videoPlayer.errorReceived    += OnErrorReceived;
         }
 
         private void OnDestroy()
         {
             videoPlayer.prepareCompleted -= OnPrepareCompleted;
-            videoPlayer.started -= OnStarted;
+            videoPlayer.started          -= OnStarted;
             videoPlayer.loopPointReached -= OnLoopPointReached;
+            videoPlayer.errorReceived    -= OnErrorReceived;
         }
 
-        public async UniTask PlayAsync(string id, Ct ct)
+        public async UniTask PlayAsync(Ct ct)
         {
             ct.ThrowIfCancellationRequested();
 
-            if (isPlaying)
+            if (IsPlaying)
             {
-                $"既に{currentPlayingId}のカットシーンが再生中です。".Print(LogSettings.Warning);
+                "既にカットシーンが再生中です。".Print(LogSettings.Warning);
                 return;
             }
 
-            // 状態を更新
-            isPlaying = true;
-            currentPlayingId = id; // 元に戻すことはない
-            OnBeginPlay();
-
-            "カットシーンのダウンロード中...".Print();
-
-            string url = id;
-            (bool success, string savePath) = await DownloadManager.Instance.DownloadFileAsync(url, true, ct);
-            if (!success)
+            if (videoClip == null)
             {
-                "カットシーンのダウンロードに失敗したため、再生を中止します。".Print(LogSettings.Error);
-
-                // 状態をリセット
-                OnEndPlay();
-                isPlaying = false;
-
+                "VideoClip が設定されていません。".Print(LogSettings.Error);
                 return;
             }
 
-            "カットシーンのダウンロードに成功しました。再生準備中...".Print();
+            IsPlaying = true;
 
-            // 再生する
-            videoPlayer.Stop(); // 念のため、明示的にストップ
-            videoPlayer.url = ""; // URLをクリアしないとPrepareが動作しない場合がある
-            videoPlayer.url = ZString.Format("file://{0}", savePath); // 元に戻すことはない
+            // フェードイン中に呼び出し元がキャンセルした場合、フェードインを止めてからフェードアウトへ移行するため
+            // ct と destroyCancellationToken の両方でキャンセルできるリンクトークンを渡す
+            using Cts linkedBeginCts = Cts.CreateLinkedTokenSource(ct, destroyCancellationToken);
+            OnBeginPlayAsync(bgFadeDuration, linkedBeginCts.Token).Forget();
+
+            "カットシーンの再生準備中...".Print();
+
+            // VideoClip を設定して準備する
+            videoPlayer.Stop();
+            videoPlayer.clip = videoClip;
             videoPlayer.Prepare();
-
-            "カットシーンの再生を開始しました。".Print();
 
             try
             {
-                await UniTask.WaitUntil(() => !isPlaying, cancellationToken: ct);
+                await UniTask.WaitUntil(() => !IsPlaying, cancellationToken: ct);
             }
             catch (OperationCanceledException)
             {
                 "カットシーンの再生がキャンセルされました。".Print(LogSettings.Warning);
             }
-            // キャンセル時、確実に状態をリセットする
             finally
             {
-                if (isPlaying)
+                if (IsPlaying)
                 {
-                    OnEndPlay();
-                    isPlaying = false;
+                    // フェードインが進行中ならここで停止させ、フェードアウトと競合しないようにする
+                    linkedBeginCts.Cancel();
+                    videoPlayer.Stop();
+                    rawImage.enabled = false;
+                    OnEndPlayAsync(bgFadeDuration, destroyCancellationToken).Forget();
+                    IsPlaying = false;
                 }
             }
         }
@@ -101,8 +94,9 @@ namespace MyScripts.Runtime
         #region 内部デリゲート
 
         private void OnPrepareCompleted(VideoPlayer _) => OnPrepareCompletedInternal();
-        private void OnStarted(VideoPlayer _) => OnStartedInternal();
+        private void OnStarted(VideoPlayer _)          => OnStartedInternal();
         private void OnLoopPointReached(VideoPlayer _) => OnLoopPointReachedInternal();
+        private void OnErrorReceived(VideoPlayer _, string message) => OnErrorReceivedInternal(message);
 
         private void OnPrepareCompletedInternal()
         {
@@ -113,48 +107,53 @@ namespace MyScripts.Runtime
         private void OnStartedInternal()
         {
             rawImage.enabled = true;
+            "カットシーンの再生を開始しました。".Print();
         }
 
         private void OnLoopPointReachedInternal()
         {
             rawImage.enabled = false;
 
-            OnEndPlay();
-            isPlaying = false;
+            OnEndPlayAsync(bgFadeDuration, destroyCancellationToken).Forget();
+            IsPlaying = false;
+        }
+
+        // Prepare 失敗など VideoPlayer 内部エラー時の後始末
+        // IsPlaying を false にすることで PlayAsync の WaitUntil を解除し、無限待機を防ぐ
+        private void OnErrorReceivedInternal(string message)
+        {
+            $"VideoPlayer でエラーが発生したため、再生を中止します。エラー: {message}".Print(LogSettings.Error);
+
+            if (!IsPlaying) return;
+
+            videoPlayer.Stop();
+            rawImage.enabled = false;
+            OnEndPlayAsync(bgFadeDuration, destroyCancellationToken).Forget();
+            IsPlaying = false;
         }
 
         #endregion
 
-        private void OnBeginPlay()
+        private async UniTaskVoid OnBeginPlayAsync(float duration, Ct ct)
         {
             InputManager.DisableAllInputs();
-            FadeInBgAsync(destroyCancellationToken).Forget();
-        }
 
-        private void OnEndPlay()
-        {
-            InputManager.EnableAllInputs();
-            FadeOutBgAsync(destroyCancellationToken).Forget();
-        }
-
-        // 重複実行はバグると思う
-        private async UniTaskVoid FadeInBgAsync(Ct ct)
-        {
             SetBgAlpha(0.0f);
             bg.enabled = true;
 
-            await LMotion.Create(0.0f, bgAlphaMax, bgFadeDuration)
+            await LMotion.Create(0.0f, bgAlphaMax, duration)
                         .WithEase(Ease.OutQuad)
                         .Bind(SetBgAlpha)
                         .ToUniTask(cancellationToken: ct);
         }
 
-        // 重複実行はバグると思う
-        private async UniTaskVoid FadeOutBgAsync(Ct ct)
+        private async UniTaskVoid OnEndPlayAsync(float duration, Ct ct)
         {
+            InputManager.EnableAllInputs();
+
             SetBgAlpha(bgAlphaMax);
 
-            await LMotion.Create(bgAlphaMax, 0.0f, bgFadeDuration)
+            await LMotion.Create(bgAlphaMax, 0.0f, duration)
                         .WithEase(Ease.InQuad)
                         .Bind(SetBgAlpha)
                         .ToUniTask(cancellationToken: ct);

--- a/Assets/_MyAssets/Scripts/Runtime/IntroPlayer.cs
+++ b/Assets/_MyAssets/Scripts/Runtime/IntroPlayer.cs
@@ -3,12 +3,13 @@
 namespace MyScripts.Runtime
 {
     /// <summary>
-    /// 初めてゲームを開始した際に、最初に流れるイントロ画像シーケンスを再生するクラス
+    /// 初めてゲームを開始した際に、最初に流れるイントロを再生するクラス
     /// </summary>
     internal sealed class IntroPlayer : MonoBehaviour
     {
         [SerializeField] private Sprite[] sequenceSprites;
-        [SerializeField, Range(0.0f, 10.0f)] private float durationUntilPlay = 0.5f;
+        [SerializeField, Range(0.0f, 10.0f)] private float durationUntilStoryMovie = 0.5f;
+        [SerializeField, Range(0.0f, 10.0f)] private float durationUntilTutorialImages = 1.0f;
         [SerializeField] private ImageSequencePlayerPlayOptions playOptions;
         [SerializeField] private PauseInvoker pauseInvoker;
         [SerializeField] private SStoryMovie storyMovie;
@@ -21,14 +22,20 @@ namespace MyScripts.Runtime
             if (!Variables.IsFirstPlay)
                 return;
 
-            await durationUntilPlay.SecAwait(ct: ct);
-            // ポーズでなくなるまで待機
+            await durationUntilStoryMovie.SecAwait(ct: ct);
+            await WaitUntilUnPaused(ct);
+            await CutScenePlayer.Instance.PlayAsync(storyMovie.Get(SStoryMovie.GameProgress.P0), ct);
+
+            await durationUntilTutorialImages.SecAwait(ct: ct);
+            await WaitUntilUnPaused(ct);
+            await ImageSequencePlayer.Instance.PlayAsync(sequenceSprites, playOptions, ct);
+        }
+
+        // ポーズでなくなるまで待機する
+        private async UniTask WaitUntilUnPaused(Ct ct)
+        {
             await UniTask.WaitUntil(pauseInvoker,
                 static pauseInvoker => !pauseInvoker.IsPaused, cancellationToken: ct);
-
-            // まず動画を再生し、終了後にチュートリアルシーケンスを再生
-            await CutScenePlayer.Instance.PlayAsync(storyMovie.Get(SStoryMovie.GameProgress.P0), ct);
-            await ImageSequencePlayer.Instance.PlayAsync(sequenceSprites, playOptions, ct);
         }
     }
 }

--- a/Assets/_MyAssets/Scripts/Runtime/IntroPlayer.cs
+++ b/Assets/_MyAssets/Scripts/Runtime/IntroPlayer.cs
@@ -11,6 +11,7 @@ namespace MyScripts.Runtime
         [SerializeField, Range(0.0f, 10.0f)] private float durationUntilPlay = 0.5f;
         [SerializeField] private ImageSequencePlayerPlayOptions playOptions;
         [SerializeField] private PauseInvoker pauseInvoker;
+        [SerializeField] private SStoryMovie storyMovie;
 
         // 他の初期化後に実行する
         private void Start() => ImplAsync(destroyCancellationToken).Forget();
@@ -26,7 +27,7 @@ namespace MyScripts.Runtime
                 static pauseInvoker => !pauseInvoker.IsPaused, cancellationToken: ct);
 
             // まず動画を再生し、終了後にチュートリアルシーケンスを再生
-            await CutScenePlayer.Instance.PlayAsync(ct);
+            await CutScenePlayer.Instance.PlayAsync(storyMovie.Get(SStoryMovie.GameProgress.P0), ct);
             await ImageSequencePlayer.Instance.PlayAsync(sequenceSprites, playOptions, ct);
         }
     }

--- a/Assets/_MyAssets/Scripts/Runtime/IntroPlayer.cs
+++ b/Assets/_MyAssets/Scripts/Runtime/IntroPlayer.cs
@@ -25,6 +25,8 @@ namespace MyScripts.Runtime
             await UniTask.WaitUntil(pauseInvoker,
                 static pauseInvoker => !pauseInvoker.IsPaused, cancellationToken: ct);
 
+            // まず動画を再生し、終了後にチュートリアルシーケンスを再生
+            await CutScenePlayer.Instance.PlayAsync(ct);
             await ImageSequencePlayer.Instance.PlayAsync(sequenceSprites, playOptions, ct);
         }
     }

--- a/Assets/_MyAssets/Scripts/SO/Movie.meta
+++ b/Assets/_MyAssets/Scripts/SO/Movie.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2c319a0544bc4dceaa087c48255a4af9
+timeCreated: 1776512286

--- a/Assets/_MyAssets/Scripts/SO/Movie/SStoryMovie.cs
+++ b/Assets/_MyAssets/Scripts/SO/Movie/SStoryMovie.cs
@@ -1,0 +1,30 @@
+﻿using UnityEngine.Video;
+
+namespace MyScripts.SO
+{
+    [CreateAssetMenu(fileName = "_StoryMovie", menuName = "SO/Movie/Story Movie")]
+    internal sealed class SStoryMovie : ScriptableObject
+    {
+        internal enum GameProgress : byte
+        {
+            P0,
+            P33,
+            P66,
+            P100,
+        }
+
+        [SerializeField] private VideoClip p0;
+        [SerializeField] private VideoClip p33;
+        [SerializeField] private VideoClip p66;
+        [SerializeField] private VideoClip p100;
+
+        internal VideoClip Get(GameProgress progress) => progress switch
+        {
+            GameProgress.P0   => p0,
+            GameProgress.P33  => p33,
+            GameProgress.P66  => p66,
+            GameProgress.P100 => p100,
+            _                 => throw new ArgumentOutOfRangeException(nameof(progress), progress, null)
+        };
+    }
+}

--- a/Assets/_MyAssets/Scripts/SO/Movie/SStoryMovie.cs.meta
+++ b/Assets/_MyAssets/Scripts/SO/Movie/SStoryMovie.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 827106550c474d4ebd7ef1dad9128393
+timeCreated: 1776512318

--- a/Assets/_MyAssets/Scripts/SO/Movie/_StoryMovie.asset
+++ b/Assets/_MyAssets/Scripts/SO/Movie/_StoryMovie.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 827106550c474d4ebd7ef1dad9128393, type: 3}
+  m_Name: _StoryMovie
+  m_EditorClassIdentifier: MyScripts::MyScripts.SO.SStoryMovie
+  p0: {fileID: 0}
+  p33: {fileID: 0}
+  p66: {fileID: 0}
+  p100: {fileID: 0}

--- a/Assets/_MyAssets/Scripts/SO/Movie/_StoryMovie.asset
+++ b/Assets/_MyAssets/Scripts/SO/Movie/_StoryMovie.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 827106550c474d4ebd7ef1dad9128393, type: 3}
   m_Name: _StoryMovie
   m_EditorClassIdentifier: MyScripts::MyScripts.SO.SStoryMovie
-  p0: {fileID: 0}
-  p33: {fileID: 0}
-  p66: {fileID: 0}
-  p100: {fileID: 0}
+  p0: {fileID: 32900000, guid: 1c659e30ed5efc44c94c2bdf43a59b67, type: 3}
+  p33: {fileID: 32900000, guid: df5cbd7ced356984fb6e04fa7ed2dcc3, type: 3}
+  p66: {fileID: 32900000, guid: 1f6c22b3c9ef48e498ebfb3525cf149b, type: 3}
+  p100: {fileID: 32900000, guid: 0f9437f89ea2a704987af8ed4b954637, type: 3}

--- a/Assets/_MyAssets/Scripts/SO/Movie/_StoryMovie.asset.meta
+++ b/Assets/_MyAssets/Scripts/SO/Movie/_StoryMovie.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a3c3ad9930d7e894cb66aa5d272f446b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 概要

- カットシーン動画の再生方式を URL ダウンロードから VideoClip 直接アサインに変更
- ゲームシーン開始時にチュートリアルシーケンスの前に動画が再生されるよう対応した

## 行わなかったこと

- 動画の手動スキップ機能（無くて良さそう）

## プレイ動画

https://github.com/user-attachments/assets/83f1dfa6-aaef-487b-873e-46eb27291b93

