### PR TITLE
慣性ジャンプの発動条件に、目の前が崖であることを追加

### DIFF
--- a/Assets/_MyAssets/Scripts/Runtime/PlayerController.cs
+++ b/Assets/_MyAssets/Scripts/Runtime/PlayerController.cs
@@ -16,23 +16,26 @@ namespace MyScripts.Runtime
             internal GameObject Get(SWalkSound.Surface surface) => surface switch
             {
                 SWalkSound.Surface.Grass => grass,
-                SWalkSound.Surface.Sand => sand,
-                SWalkSound.Surface.Rock => rock,
+                SWalkSound.Surface.Sand  => sand,
+                SWalkSound.Surface.Rock  => rock,
                 SWalkSound.Surface.Water => water,
-                _ => throw new ArgumentOutOfRangeException(nameof(surface), surface, null)
+                _                        => throw new ArgumentOutOfRangeException(nameof(surface), surface, null)
             };
         }
 
         [Header("Player Control")]
         [SerializeField] private CharacterController controller;
+
         [SerializeField] private AnimalLeaveInvoker animalLeaveInvoker;
         [SerializeField] private CameraFOVManager cameraFOVManager;
         [SerializeField] private PlayerControlSoundPlayer soundPlayer;
         [SerializeField] private Transform cinemachineCameraTarget;
         [SerializeField] private Transform teleportBackPoint;
+
         [Space(10)]
         [Header("Walk Sound")]
         [SerializeField] private WalkSoundPlayer walkSoundPlayer;
+
         [SerializeField] private WalkSoundBorderRoots walkSoundBorderRoots;
 
         // cinemachine
@@ -47,14 +50,14 @@ namespace MyScripts.Runtime
         private bool isGrounded = true;
         private bool hasBecameGroundedThisFrame = false;
         private bool hasBecameNotGroundedThisFrame = false;
-        private Vector3 becameGroundedPosition = Vector3.zero; // 一番最後に地面に着地した位置を記録しておく
+        private Vector3 becameGroundedPosition = Vector3.zero;    // 一番最後に地面に着地した位置を記録しておく
         private Vector3 becameNotGroundedPosition = Vector3.zero; // 一番最後に地面から離れた位置を記録しておく
         private bool isJumping = false;
         private bool isSprinting = false;
         private bool isDoingInertiaJump = false;
         private bool onInertiaJumpCt = false;
         private Vector3 previousFramePosition = Vector3.zero; // 直前フレームの位置を記録して、戻せるようにする
-        private int jumpCountWhenHasSky = 0; // 空のアニマを取得している時、空中ジャンプ出来るので、二段ジャンプより上を防止する用
+        private int jumpCountWhenHasSky = 0;                  // 空のアニマを取得している時、空中ジャンプ出来るので、二段ジャンプより上を防止する用
 
         // timeout deltatime
         // Awake で初期化
@@ -64,6 +67,7 @@ namespace MyScripts.Runtime
 
         // constraints
         private bool isOwnGravityEnabled = true;
+
         internal bool IsOwnGravityEnabled
         {
             get => isOwnGravityEnabled;
@@ -79,20 +83,26 @@ namespace MyScripts.Runtime
                 }
             }
         }
+
         internal bool CanApplyVelocityDelta { get; set; } = true;
 
         // walk sound
         private byte walkSoundUpdateIntervalFrames; // Awake で初期化
+
         private byte walkSoundUpdateFrameCounter = 0;
+
         // 最初の方 (= 上の地層にある地面) を優先して鳴らす
-        private static readonly ReadOnlyCollection<SWalkSound.Surface> WalkSoundPriority = Array.AsReadOnly(new SWalkSound.Surface[]
-        {
-            SWalkSound.Surface.Rock,
-            SWalkSound.Surface.Water,
-            SWalkSound.Surface.Sand,
-            SWalkSound.Surface.Grass,
-        });
-        private readonly Dictionary<SWalkSound.Surface, ReadOnlyCollection<Border>> walkSoundBorders = new(); // Awake で初期化
+        private static readonly ReadOnlyCollection<SWalkSound.Surface> WalkSoundPriority = Array.AsReadOnly(
+            new SWalkSound.Surface[]
+            {
+                SWalkSound.Surface.Rock,
+                SWalkSound.Surface.Water,
+                SWalkSound.Surface.Sand,
+                SWalkSound.Surface.Grass,
+            });
+
+        private readonly Dictionary<SWalkSound.Surface, ReadOnlyCollection<Border>>
+            walkSoundBorders = new(); // Awake で初期化
 
         #region Public Methods and Properties
 
@@ -204,8 +214,10 @@ namespace MyScripts.Runtime
             bool isGroundedPrev = isGrounded;
 
             // set sphere position, with offset
-            Vector3 spherePosition = new(transform.position.x, transform.position.y + param.GroundCheckOffset, transform.position.z);
-            isGrounded = Physics.CheckSphere(spherePosition, param.GroundCheckRadius, param.GroundLayers, QueryTriggerInteraction.Ignore);
+            Vector3 spherePosition = new(transform.position.x, transform.position.y + param.GroundCheckOffset,
+                transform.position.z);
+            isGrounded = Physics.CheckSphere(spherePosition, param.GroundCheckRadius, param.GroundLayers,
+                QueryTriggerInteraction.Ignore);
 
             hasBecameGroundedThisFrame = isGrounded && !isGroundedPrev;
             hasBecameNotGroundedThisFrame = !isGrounded && isGroundedPrev;
@@ -306,8 +318,9 @@ namespace MyScripts.Runtime
             // attenuate the native velocity
             if (nativeHorizontalVelocity != Vector2.zero)
             {
-                float attenuationRate = isGrounded ?
-                    param.NativeHorizontalVelocityAttenuationRateOnGround : param.NativeHorizontalVelocityAttenuationRateInAir;
+                float attenuationRate = isGrounded
+                    ? param.NativeHorizontalVelocityAttenuationRateOnGround
+                    : param.NativeHorizontalVelocityAttenuationRateInAir;
                 nativeHorizontalVelocity -= nativeHorizontalVelocity * attenuationRate;
 
                 if (nativeHorizontalVelocity.sqrMagnitude < 1e-4f)
@@ -321,16 +334,17 @@ namespace MyScripts.Runtime
         {
             // get input
             Vector2 input = InputManager.PlayerControl.Move;
-            Vector3 inputDirection = new Vector3(input.x, 0.0f, input.y).normalized;　// normalise input direction
-            bool isInputSpecifiedAngle = false; //入力方向と体のなす角が走行時の視野角に収まっているか
+            Vector3 inputDirection = new Vector3(input.x, 0.0f, input.y).normalized; // normalise input direction
+            bool isInputSpecifiedAngle = false;                                      //入力方向と体のなす角が走行時の視野角に収まっているか
             bool isSprintingInput = InputManager.PlayerControl.Sprint;
             // note: Vector2's != operator uses approximation so is not floating point error prone, and is cheaper than magnitude
             bool hasInput = input != Vector2.zero;
-            if(hasInput)
+            if (hasInput)
             {
                 inputDirection = transform.right * input.x + transform.forward * input.y;
                 isInputSpecifiedAngle = IsMovingForward(inputDirection);
             }
+
             inputDirection.Normalize();
             isSprinting = isSprintingInput && hasInput && isInputSpecifiedAngle; //ここに接地条件を入れてもよいかもしれない
 
@@ -348,6 +362,7 @@ namespace MyScripts.Runtime
                     targetSpeed += param.MoveSpeedIncreaseWhenHasSea;
                 }
             }
+
             if (animalLeaveInvoker.IsPossessingType(CharacterType.Land))
             {
                 // Water 以外の場所を陸上とみなす
@@ -357,6 +372,7 @@ namespace MyScripts.Runtime
                     targetSpeed += param.MoveSpeedIncreaseWhenHasLand;
                 }
             }
+
             if (animalLeaveInvoker.IsPossessingType(CharacterType.Sky))
             {
                 if (jumpCountWhenHasSky > 0) targetSpeed += param.MoveSpeedIncreaseWhenHasSkyAndInTheAir;
@@ -386,11 +402,13 @@ namespace MyScripts.Runtime
 
             // accelerate or decelerate to target speed
             float speed;
-            if (currentHorizontalSpeed < targetSpeed - speedOffset || currentHorizontalSpeed > targetSpeed + speedOffset)
+            if (currentHorizontalSpeed < targetSpeed - speedOffset ||
+                currentHorizontalSpeed > targetSpeed + speedOffset)
             {
                 // creates curved result rather than a linear one giving a more organic speed change
                 // note T in Lerp is clamped, so we don't need to clamp our speed
-                speed = Mathf.Lerp(currentHorizontalSpeed, targetSpeed * inputMagnitude, Time.deltaTime * param.MoveAcceleration);
+                speed = Mathf.Lerp(currentHorizontalSpeed, targetSpeed * inputMagnitude,
+                    Time.deltaTime * param.MoveAcceleration);
 
                 // round speed to 3 decimal places
                 speed = Mathf.Round(speed * 1000f) / 1000f;
@@ -408,7 +426,8 @@ namespace MyScripts.Runtime
                     inputDirection *= param.MoveInputInsensitiveRate;
                 }
             }
-            else if (param.MoveInputInsensitiveTiming == SPlayerControl.MoveInputInsensitiveTimingType.WhileInAirAndWhenOuterVelocityIsNotZero)
+            else if (param.MoveInputInsensitiveTiming ==
+                     SPlayerControl.MoveInputInsensitiveTimingType.WhileInAirAndWhenOuterVelocityIsNotZero)
             {
                 if (!isGrounded && nativeHorizontalVelocity != Vector2.zero)
                 {
@@ -417,7 +436,8 @@ namespace MyScripts.Runtime
             }
 
             // calculate the real velocity
-            realHorizontalVelocity = inputDirection * speed + new Vector3(nativeHorizontalVelocity.x, 0.0f, nativeHorizontalVelocity.y);
+            realHorizontalVelocity = inputDirection * speed +
+                                     new Vector3(nativeHorizontalVelocity.x, 0.0f, nativeHorizontalVelocity.y);
             Vector3 realVelocity = realHorizontalVelocity + new Vector3(0.0f, verticalVelocity, 0.0f);
 
             // 外力による速度増加分を加算
@@ -551,9 +571,9 @@ namespace MyScripts.Runtime
             // ゲーム世界の範囲外か?
             // 初期位置に戻す
             if (controller.transform.position is
-            { x: < -1600 or > 1600 } or
-            { y: < -50 or > 500 } or
-            { z: < -1600 or > 1600 })
+                { x: < -1600 or > 1600 } or
+                { y: < -50 or > 500 } or
+                { z: < -1600 or > 1600 })
                 controller.transform.position = teleportBackPoint.position;
         }
 
@@ -624,7 +644,6 @@ namespace MyScripts.Runtime
         }
 
 
-
         private static bool IsInsideOfAnyBorder(IReadOnlyList<Border> borders, Vector3 position, byte targetLayer)
         {
             for (int i = 0; i < borders.Count; i++)
@@ -633,6 +652,7 @@ namespace MyScripts.Runtime
                 if (border.DoesContain(position, targetLayer))
                     return true;
             }
+
             return false;
         }
 

--- a/Assets/_MyAssets/Scripts/Runtime/PlayerController.cs
+++ b/Assets/_MyAssets/Scripts/Runtime/PlayerController.cs
@@ -263,14 +263,15 @@ namespace MyScripts.Runtime
             if (!hasBecameNotGroundedThisFrame) return;
 
             // 目の前が崖であるべき
-            if (Physics.Raycast(
-                    transform.position + transform.forward * param.InertiaJumpCliffCheckDistanceFromPlayer,
-                    Vector3.down,
-                    param.InertiaJumpCliffCheckDistanceDownward,
-                    param.GroundLayers,
-                    QueryTriggerInteraction.Ignore
-                ))
-                return;
+            {
+                if (!TryMeasureCliffHeight(param.InertiaJumpCliffCheckDistanceFromPlayerNear, out float heightNear))
+                    return; // 検出失敗
+                if (!TryMeasureCliffHeight(param.InertiaJumpCliffCheckDistanceFromPlayerFar, out float heightFar))
+                    return; // 検出失敗
+
+                if (heightFar - heightNear > param.InertiaJumpCliffCheckHeightDifferenceLimit)
+                    return;
+            }
 
             // 処理を行える
 
@@ -642,6 +643,37 @@ namespace MyScripts.Runtime
             return (Vector2.Dot(playerForwardXZ, moveDirectionXZ) > threshold);
         }
 
+        /// <summary>
+        /// プレイヤーの少し前方(足元)から下方向にレイを飛ばし、<br/>
+        /// 何m下部で地面にヒットしたかを検出する<br/>
+        /// </summary>
+        /// <param name="forwardDistance">プレイヤーの足元の座標より、前方に 〇[m] 離れたところからレイを飛ばす</param>
+        /// <param name="height">成功した場合、レイを飛ばした位置とヒットした地面のY座標の差の絶対値(正)<br/>
+        /// 失敗した場合、0.0f</param>
+        /// <returns>成功したら true、失敗したら false</returns>
+        private bool TryMeasureCliffHeight(float forwardDistance, out float height)
+        {
+            // 十分長く取る
+            const float RayLength = 1000.0f;
+
+            if (Physics.Raycast(
+                    transform.position + transform.forward * forwardDistance,
+                    Vector3.down,
+                    out RaycastHit hitInfo,
+                    RayLength,
+                    param.GroundLayers,
+                    QueryTriggerInteraction.Ignore
+                ))
+            {
+                height = hitInfo.distance;
+                return true;
+            }
+            else
+            {
+                height = 0.0f;
+                return false;
+            }
+        }
 
         private static bool IsInsideOfAnyBorder(IReadOnlyList<Border> borders, Vector3 position, byte targetLayer)
         {

--- a/Assets/_MyAssets/Scripts/Runtime/PlayerController.cs
+++ b/Assets/_MyAssets/Scripts/Runtime/PlayerController.cs
@@ -263,15 +263,14 @@ namespace MyScripts.Runtime
             if (!hasBecameNotGroundedThisFrame) return;
 
             // 目の前が崖であるべき
-            {
-                Ray ray = new(
-                    transform.position + Vector3.forward * param.InertiaJumpCliffCheckDistanceFromPlayer,
-                    Vector3.down
-                );
-
-                if (Physics.Raycast(ray, param.InertiaJumpCliffCheckDistanceDownward, param.GroundLayers))
-                    return;
-            }
+            if (Physics.Raycast(
+                    transform.position + transform.forward * param.InertiaJumpCliffCheckDistanceFromPlayer,
+                    Vector3.down,
+                    param.InertiaJumpCliffCheckDistanceDownward,
+                    param.GroundLayers,
+                    QueryTriggerInteraction.Ignore
+                ))
+                return;
 
             // 処理を行える
 

--- a/Assets/_MyAssets/Scripts/Runtime/PlayerController.cs
+++ b/Assets/_MyAssets/Scripts/Runtime/PlayerController.cs
@@ -250,7 +250,16 @@ namespace MyScripts.Runtime
             // 現在、地面から離れたタイミングであるべき
             if (!hasBecameNotGroundedThisFrame) return;
 
-            //? 目の前が崖であるべきか？
+            // 目の前が崖であるべき
+            {
+                Ray ray = new(
+                    transform.position + Vector3.forward * param.InertiaJumpCliffCheckDistanceFromPlayer,
+                    Vector3.down
+                );
+
+                if (Physics.Raycast(ray, param.InertiaJumpCliffCheckDistanceDownward, param.GroundLayers))
+                    return;
+            }
 
             // 処理を行える
 

--- a/Assets/_MyAssets/Scripts/SO/InGame/SPlayerControl.cs
+++ b/Assets/_MyAssets/Scripts/SO/InGame/SPlayerControl.cs
@@ -68,15 +68,22 @@
         [Header("Inertia Jump")]
         [SerializeField, Tooltip("加算する速度(プレイヤーから見た相対ベクトル)")] private Vector3 inertiaJumpVelocity = new(30.0f, 15.0f, 30.0f);
         [SerializeField, Tooltip("必要な水平速度 の平方")] private float inertiaJumpLimitSpeedSqr = 100.0f;
-        [SerializeField, Tooltip("地面から離地した時、目の前 〇m から下方向に △m 地面で無い(= 崖)ならば、慣性ジャンプを行える : 〇の値")]
-        private float inertiaJumpCliffCheckDistanceFromPlayer = 0.5f;
-        [SerializeField, Tooltip("地面から離地した時、目の前 〇m から下方向に △m 地面で無い(= 崖)ならば、慣性ジャンプを行える : △の値")]
-        private float inertiaJumpCliffCheckDistanceDownward = 10.0f;
+        /*
+         * 地面から離地した時、目の前 x1[m] < x2[m] からそれぞれ下方向にレイを打つ
+         * レイがヒットした地点の、地面との高さの差分をそれぞれ y1[m], y2[m] > 0.0f とすると、
+         * y2 - y1 > 〇[m] の時、地面の傾きが急激に変化している = 目の前が崖であると判定して、
+         * 慣性ジャンプを行うことが出来る
+         */
+        [SerializeField, MinMaxRange(0.0f, 2.0f), Tooltip("崖判定において、レイを打つ水平距離 (near, far)")]
+        private Vector2 inertiaJumpCliffCheckDistanceFromPlayerRange = new(0.65f, 1.05f);
+        [SerializeField, Range(0.0f, 5.0f), Tooltip("崖判定において、レイのヒット地点の高低差が 〇m より大きければ、崖と判定する")]
+        private float inertiaJumpCliffCheckHeightDifferenceLimit = 0.22f;
         [SerializeField] private float inertiaJumpCoolTime = 0.2f;
         internal Vector3 InertiaJumpVelocity => inertiaJumpVelocity;
         internal float InertiaJumpLimitSpeedSqr => inertiaJumpLimitSpeedSqr;
-        internal float InertiaJumpCliffCheckDistanceFromPlayer => inertiaJumpCliffCheckDistanceFromPlayer;
-        internal float InertiaJumpCliffCheckDistanceDownward => inertiaJumpCliffCheckDistanceDownward;
+        internal float InertiaJumpCliffCheckDistanceFromPlayerNear => inertiaJumpCliffCheckDistanceFromPlayerRange.x;
+        internal float InertiaJumpCliffCheckDistanceFromPlayerFar => inertiaJumpCliffCheckDistanceFromPlayerRange.y;
+        internal float InertiaJumpCliffCheckHeightDifferenceLimit => inertiaJumpCliffCheckHeightDifferenceLimit;
         internal float InertiaJumpCoolTime => inertiaJumpCoolTime;
 
         [Space(10)]

--- a/Assets/_MyAssets/Scripts/SO/InGame/SPlayerControl.cs
+++ b/Assets/_MyAssets/Scripts/SO/InGame/SPlayerControl.cs
@@ -68,9 +68,15 @@
         [Header("Inertia Jump")]
         [SerializeField, Tooltip("加算する速度(プレイヤーから見た相対ベクトル)")] private Vector3 inertiaJumpVelocity = new(30.0f, 15.0f, 30.0f);
         [SerializeField, Tooltip("必要な水平速度 の平方")] private float inertiaJumpLimitSpeedSqr = 100.0f;
+        [SerializeField, Tooltip("地面から離地した時、目の前 〇m から下方向に △m 地面で無い(= 崖)ならば、慣性ジャンプを行える : 〇の値")]
+        private float inertiaJumpCliffCheckDistanceFromPlayer = 0.5f;
+        [SerializeField, Tooltip("地面から離地した時、目の前 〇m から下方向に △m 地面で無い(= 崖)ならば、慣性ジャンプを行える : △の値")]
+        private float inertiaJumpCliffCheckDistanceDownward = 10.0f;
         [SerializeField] private float inertiaJumpCoolTime = 0.2f;
         internal Vector3 InertiaJumpVelocity => inertiaJumpVelocity;
         internal float InertiaJumpLimitSpeedSqr => inertiaJumpLimitSpeedSqr;
+        internal float InertiaJumpCliffCheckDistanceFromPlayer => inertiaJumpCliffCheckDistanceFromPlayer;
+        internal float InertiaJumpCliffCheckDistanceDownward => inertiaJumpCliffCheckDistanceDownward;
         internal float InertiaJumpCoolTime => inertiaJumpCoolTime;
 
         [Space(10)]

--- a/Assets/_MyAssets/Scripts/SO/InGame/_PlayerControl.asset
+++ b/Assets/_MyAssets/Scripts/SO/InGame/_PlayerControl.asset
@@ -31,8 +31,8 @@ MonoBehaviour:
   ownGravityWhenHasSkyAndIsFalling: -0.6
   inertiaJumpVelocity: {x: 60, y: 15, z: 60}
   inertiaJumpLimitSpeedSqr: 100
-  inertiaJumpCliffCheckDistanceFromPlayerRange: {x: 0.65, y: 1.05}
-  inertiaJumpCliffCheckHeightDifferenceLimit: 0.22
+  inertiaJumpCliffCheckDistanceFromPlayerRange: {x: 0.6, y: 1.3}
+  inertiaJumpCliffCheckHeightDifferenceLimit: 2
   inertiaJumpCoolTime: 0.1
   jumpTimeout: 0.1
   fallTimeout: 0.15

--- a/Assets/_MyAssets/Scripts/SO/InGame/_PlayerControl.asset
+++ b/Assets/_MyAssets/Scripts/SO/InGame/_PlayerControl.asset
@@ -31,8 +31,8 @@ MonoBehaviour:
   ownGravityWhenHasSkyAndIsFalling: -0.6
   inertiaJumpVelocity: {x: 60, y: 15, z: 60}
   inertiaJumpLimitSpeedSqr: 100
-  inertiaJumpCliffCheckDistanceFromPlayer: 0.5
-  inertiaJumpCliffCheckDistanceDownward: 10
+  inertiaJumpCliffCheckDistanceFromPlayer: 0.4
+  inertiaJumpCliffCheckDistanceDownward: 0.3
   inertiaJumpCoolTime: 0.1
   jumpTimeout: 0.1
   fallTimeout: 0.15

--- a/Assets/_MyAssets/Scripts/SO/InGame/_PlayerControl.asset
+++ b/Assets/_MyAssets/Scripts/SO/InGame/_PlayerControl.asset
@@ -29,8 +29,10 @@ MonoBehaviour:
   jumpHeightWhenHasSkyAndInTheAir: 30
   ownGravity: -15
   ownGravityWhenHasSkyAndIsFalling: -0.6
-  inertiaJumpVelocity: {x: 30, y: 15, z: 30}
+  inertiaJumpVelocity: {x: 60, y: 15, z: 60}
   inertiaJumpLimitSpeedSqr: 100
+  inertiaJumpCliffCheckDistanceFromPlayer: 0.5
+  inertiaJumpCliffCheckDistanceDownward: 10
   inertiaJumpCoolTime: 0.1
   jumpTimeout: 0.1
   fallTimeout: 0.15

--- a/Assets/_MyAssets/Scripts/SO/InGame/_PlayerControl.asset
+++ b/Assets/_MyAssets/Scripts/SO/InGame/_PlayerControl.asset
@@ -31,8 +31,8 @@ MonoBehaviour:
   ownGravityWhenHasSkyAndIsFalling: -0.6
   inertiaJumpVelocity: {x: 60, y: 15, z: 60}
   inertiaJumpLimitSpeedSqr: 100
-  inertiaJumpCliffCheckDistanceFromPlayer: 0.4
-  inertiaJumpCliffCheckDistanceDownward: 0.3
+  inertiaJumpCliffCheckDistanceFromPlayerRange: {x: 0.65, y: 1.05}
+  inertiaJumpCliffCheckHeightDifferenceLimit: 0.22
   inertiaJumpCoolTime: 0.1
   jumpTimeout: 0.1
   fallTimeout: 0.15

--- a/Assets/_MyAssets/Scripts/SO/InGame/_PlayerControl.asset
+++ b/Assets/_MyAssets/Scripts/SO/InGame/_PlayerControl.asset
@@ -31,8 +31,8 @@ MonoBehaviour:
   ownGravityWhenHasSkyAndIsFalling: -0.6
   inertiaJumpVelocity: {x: 60, y: 15, z: 60}
   inertiaJumpLimitSpeedSqr: 100
-  inertiaJumpCliffCheckDistanceFromPlayerRange: {x: 0.6, y: 1.3}
-  inertiaJumpCliffCheckHeightDifferenceLimit: 2
+  inertiaJumpCliffCheckDistanceFromPlayerRange: {x: 0.8, y: 1.2}
+  inertiaJumpCliffCheckHeightDifferenceLimit: 0.3
   inertiaJumpCoolTime: 0.1
   jumpTimeout: 0.1
   fallTimeout: 0.15


### PR DESCRIPTION
## 概要

- 慣性ジャンプの発動条件を追加
- 慣性ジャンプの速度増加を増やす

## 行ったこと

- プレイヤーの足元前 〇m から下方向にレイを飛ばし、△m の間地面にヒットしなかったら、目の前が崖であると判定する
- 慣性ジャンプによって加算される速度について、水平方向の大きさを2倍にした

## 補足情報

- レイを飛ばす数値は、0.1の細かい調整でも挙動が変化しやすい
- 体感できるほどの変化はないかも。「草地のみ慣性ジャンプできる」とかの方がいいか？

## プレイ動画

https://github.com/user-attachments/assets/e214916f-84fc-46d6-aafa-806185299f89
