### PR TITLE
慣性ジャンプ中、ダッシュを止めたら速度増加を即座に消す

### DIFF
--- a/Assets/_MyAssets/Scripts/Runtime/PlayerController.cs
+++ b/Assets/_MyAssets/Scripts/Runtime/PlayerController.cs
@@ -311,8 +311,13 @@ namespace MyScripts.Runtime
             // 慣性ジャンプ開始時からの速度変化率
             // 減衰量を算出したいので、0~1に制限する
             Vector2 horizontalVelocityAttenuation =
-                nativeHorizontalVelocity / nativeHorizontalVelocityWhenInertiaJumpBeganLast;
-            float verticalVelocityAttenuation = verticalVelocity / verticalVelocityWhenInertiaJumpBeganLast;
+                nativeHorizontalVelocityWhenInertiaJumpBeganLast == Vector2.zero
+                    ? Vector2.zero
+                    : nativeHorizontalVelocity / nativeHorizontalVelocityWhenInertiaJumpBeganLast;
+            float verticalVelocityAttenuation =
+                verticalVelocityWhenInertiaJumpBeganLast == 0.0f
+                    ? 0.0f
+                    : verticalVelocity / verticalVelocityWhenInertiaJumpBeganLast;
             horizontalVelocityAttenuation.x = Mathf.Clamp01(horizontalVelocityAttenuation.x);
             horizontalVelocityAttenuation.y = Mathf.Clamp01(horizontalVelocityAttenuation.y);
             verticalVelocityAttenuation = Mathf.Clamp01(verticalVelocityAttenuation);

--- a/Assets/_MyAssets/Scripts/Runtime/PlayerController.cs
+++ b/Assets/_MyAssets/Scripts/Runtime/PlayerController.cs
@@ -23,20 +23,19 @@ namespace MyScripts.Runtime
             };
         }
 
+        // @formatter:off
         [Header("Player Control")]
         [SerializeField] private CharacterController controller;
-
         [SerializeField] private AnimalLeaveInvoker animalLeaveInvoker;
         [SerializeField] private CameraFOVManager cameraFOVManager;
         [SerializeField] private PlayerControlSoundPlayer soundPlayer;
         [SerializeField] private Transform cinemachineCameraTarget;
         [SerializeField] private Transform teleportBackPoint;
-
         [Space(10)]
         [Header("Walk Sound")]
         [SerializeField] private WalkSoundPlayer walkSoundPlayer;
-
         [SerializeField] private WalkSoundBorderRoots walkSoundBorderRoots;
+        // @formatter:on
 
         // cinemachine
         private float cinemachineTargetPitch;
@@ -56,8 +55,10 @@ namespace MyScripts.Runtime
         private bool isSprinting = false;
         private bool isDoingInertiaJump = false;
         private bool onInertiaJumpCt = false;
+        private Vector3 appliedOuterVelocityWhenInertiaJumpBeganLast = Vector3.zero; // 直近の慣性ジャンプで加算した速度
+        private float velocityTotalAttenuatedRateSinceInertiaJumpBegan = 0.0f; // 慣性ジャンプ開始以降、トータルの速度減衰割合
         private Vector3 previousFramePosition = Vector3.zero; // 直前フレームの位置を記録して、戻せるようにする
-        private int jumpCountWhenHasSky = 0;                  // 空のアニマを取得している時、空中ジャンプ出来るので、二段ジャンプより上を防止する用
+        private int jumpCountWhenHasSky = 0; // 空のアニマを取得している時、空中ジャンプ出来るので、二段ジャンプより上を防止する用
 
         // timeout deltatime
         // Awake で初期化
@@ -177,6 +178,7 @@ namespace MyScripts.Runtime
             JumpAndGravity();
             GroundedCheck();
             DoInertiaJumpIfTheTiming();
+            StopInertiaJumpWhenSprintEnd();
             AttenuateNativeHorizontalVelocity();
             InputAndFinallyMove();
             TeleportBackWhenInvalidPosition();
@@ -276,15 +278,40 @@ namespace MyScripts.Runtime
             // 処理を行える
 
             isDoingInertiaJump = true;
+
             Vector2 moveDirectionXZ = new Vector2(realHorizontalVelocity.x, realHorizontalVelocity.z).normalized;
             Vector3 velocity = new(
                 moveDirectionXZ.x * param.InertiaJumpVelocity.x,
                 param.InertiaJumpVelocity.y,
                 moveDirectionXZ.y * param.InertiaJumpVelocity.z
             );
+
+            appliedOuterVelocityWhenInertiaJumpBeganLast = velocity;
+            velocityTotalAttenuatedRateSinceInertiaJumpBegan = 1.0f;
             ApplyOuterVelocity(velocity);
 
             soundPlayer.LetPlay(SPlayerControlSound.Action.InertiaJump);
+        }
+
+        // 慣性ジャンプ 強制中止
+        private void StopInertiaJumpWhenSprintEnd()
+        {
+            // 慣性ジャンプ中のみ
+            if (!isDoingInertiaJump) return;
+
+            // ダッシュしていないなら
+            if (isSprinting) return;
+
+            // 慣性ジャンプによる速度増加を打ち消す
+
+            Vector3 cancelVelocity = appliedOuterVelocityWhenInertiaJumpBeganLast *
+                                     velocityTotalAttenuatedRateSinceInertiaJumpBegan;
+            ApplyOuterVelocity(-cancelVelocity);
+
+            appliedOuterVelocityWhenInertiaJumpBeganLast = Vector3.zero;
+            velocityTotalAttenuatedRateSinceInertiaJumpBegan = 0.0f;
+
+            isDoingInertiaJump = false;
         }
 
         private void CameraRotation()
@@ -318,6 +345,8 @@ namespace MyScripts.Runtime
             // attenuate the native velocity
             if (nativeHorizontalVelocity != Vector2.zero)
             {
+                Vector2 originalNativeHorizontalVelocity = nativeHorizontalVelocity;
+
                 float attenuationRate = isGrounded
                     ? param.NativeHorizontalVelocityAttenuationRateOnGround
                     : param.NativeHorizontalVelocityAttenuationRateInAir;
@@ -326,6 +355,14 @@ namespace MyScripts.Runtime
                 if (nativeHorizontalVelocity.sqrMagnitude < 1e-4f)
                 {
                     nativeHorizontalVelocity = Vector2.zero;
+                }
+
+                // update total attenuation record
+                if (velocityTotalAttenuatedRateSinceInertiaJumpBegan > 0.0f)
+                {
+                    float attenuatedRate =
+                        nativeHorizontalVelocity.magnitude / originalNativeHorizontalVelocity.magnitude;
+                    velocityTotalAttenuatedRateSinceInertiaJumpBegan *= attenuatedRate;
                 }
             }
         }

--- a/Assets/_MyAssets/Scripts/Runtime/PlayerController.cs
+++ b/Assets/_MyAssets/Scripts/Runtime/PlayerController.cs
@@ -55,8 +55,8 @@ namespace MyScripts.Runtime
         private bool isSprinting = false;
         private bool isDoingInertiaJump = false;
         private bool onInertiaJumpCt = false;
-        private Vector3 appliedOuterVelocityWhenInertiaJumpBeganLast = Vector3.zero; // 直近の慣性ジャンプで加算した速度
-        private float velocityTotalAttenuatedRateSinceInertiaJumpBegan = 0.0f; // 慣性ジャンプ開始以降、トータルの速度減衰割合
+        private Vector2 appliedHorizontalOuterVelocityWhenInertiaJumpBeganLast = Vector2.zero; // 直近の慣性ジャンプで加算した水平速度
+        private float horizontalVelocityTotalAttenuatedRateSinceInertiaJumpBegan = 0.0f; // 慣性ジャンプ開始以降、トータルの水平速度 減衰割合
         private Vector3 previousFramePosition = Vector3.zero; // 直前フレームの位置を記録して、戻せるようにする
         private int jumpCountWhenHasSky = 0; // 空のアニマを取得している時、空中ジャンプ出来るので、二段ジャンプより上を防止する用
 
@@ -286,8 +286,8 @@ namespace MyScripts.Runtime
                 moveDirectionXZ.y * param.InertiaJumpVelocity.z
             );
 
-            appliedOuterVelocityWhenInertiaJumpBeganLast = velocity;
-            velocityTotalAttenuatedRateSinceInertiaJumpBegan = 1.0f;
+            appliedHorizontalOuterVelocityWhenInertiaJumpBeganLast = new Vector2(velocity.x, velocity.z);
+            horizontalVelocityTotalAttenuatedRateSinceInertiaJumpBegan = 1.0f;
             ApplyOuterVelocity(velocity);
 
             soundPlayer.LetPlay(SPlayerControlSound.Action.InertiaJump);
@@ -304,12 +304,12 @@ namespace MyScripts.Runtime
 
             // 慣性ジャンプによる速度増加を打ち消す
 
-            Vector3 cancelVelocity = appliedOuterVelocityWhenInertiaJumpBeganLast *
-                                     velocityTotalAttenuatedRateSinceInertiaJumpBegan;
-            ApplyOuterVelocity(-cancelVelocity);
+            Vector2 cancelHorizontalVelocity = appliedHorizontalOuterVelocityWhenInertiaJumpBeganLast *
+                                               horizontalVelocityTotalAttenuatedRateSinceInertiaJumpBegan;
+            ApplyOuterVelocity(new Vector3(-cancelHorizontalVelocity.x, 0.0f, -cancelHorizontalVelocity.y));
 
-            appliedOuterVelocityWhenInertiaJumpBeganLast = Vector3.zero;
-            velocityTotalAttenuatedRateSinceInertiaJumpBegan = 0.0f;
+            appliedHorizontalOuterVelocityWhenInertiaJumpBeganLast = Vector2.zero;
+            horizontalVelocityTotalAttenuatedRateSinceInertiaJumpBegan = 0.0f;
 
             isDoingInertiaJump = false;
         }
@@ -358,11 +358,11 @@ namespace MyScripts.Runtime
                 }
 
                 // update total attenuation record
-                if (velocityTotalAttenuatedRateSinceInertiaJumpBegan > 0.0f)
+                if (horizontalVelocityTotalAttenuatedRateSinceInertiaJumpBegan > 0.0f)
                 {
                     float attenuatedRate =
                         nativeHorizontalVelocity.magnitude / originalNativeHorizontalVelocity.magnitude;
-                    velocityTotalAttenuatedRateSinceInertiaJumpBegan *= attenuatedRate;
+                    horizontalVelocityTotalAttenuatedRateSinceInertiaJumpBegan *= attenuatedRate;
                 }
             }
         }

--- a/Assets/_MyAssets/Scripts/Runtime/PlayerController.cs
+++ b/Assets/_MyAssets/Scripts/Runtime/PlayerController.cs
@@ -55,8 +55,9 @@ namespace MyScripts.Runtime
         private bool isSprinting = false;
         private bool isDoingInertiaJump = false;
         private bool onInertiaJumpCt = false;
-        private Vector2 appliedHorizontalOuterVelocityWhenInertiaJumpBeganLast = Vector2.zero; // 直近の慣性ジャンプで加算した水平速度
-        private float horizontalVelocityTotalAttenuatedRateSinceInertiaJumpBegan = 0.0f; // 慣性ジャンプ開始以降、トータルの水平速度 減衰割合
+        private Vector3 appliedOuterVelocityWhenInertiaJumpBeganLast = Vector3.zero; // 直近の慣性ジャンプ実行時の、速度増加を記録しておく
+        private Vector2 nativeHorizontalVelocityWhenInertiaJumpBeganLast = Vector2.zero; // 直近の慣性ジャンプ開始直後の、速度を記録しておく
+        private float verticalVelocityWhenInertiaJumpBeganLast = 0.0f; // 直近の慣性ジャンプ開始直後の、速度を記録しておく
         private Vector3 previousFramePosition = Vector3.zero; // 直前フレームの位置を記録して、戻せるようにする
         private int jumpCountWhenHasSky = 0; // 空のアニマを取得している時、空中ジャンプ出来るので、二段ジャンプより上を防止する用
 
@@ -178,7 +179,7 @@ namespace MyScripts.Runtime
             JumpAndGravity();
             GroundedCheck();
             DoInertiaJumpIfTheTiming();
-            StopInertiaJumpWhenSprintEnd();
+            StopInertiaJumpOnSprintEnd();
             AttenuateNativeHorizontalVelocity();
             InputAndFinallyMove();
             TeleportBackWhenInvalidPosition();
@@ -286,15 +287,17 @@ namespace MyScripts.Runtime
                 moveDirectionXZ.y * param.InertiaJumpVelocity.z
             );
 
-            appliedHorizontalOuterVelocityWhenInertiaJumpBeganLast = new Vector2(velocity.x, velocity.z);
-            horizontalVelocityTotalAttenuatedRateSinceInertiaJumpBegan = 1.0f;
+            appliedOuterVelocityWhenInertiaJumpBeganLast = velocity;
             ApplyOuterVelocity(velocity);
+
+            nativeHorizontalVelocityWhenInertiaJumpBeganLast = nativeHorizontalVelocity;
+            verticalVelocityWhenInertiaJumpBeganLast = verticalVelocity;
 
             soundPlayer.LetPlay(SPlayerControlSound.Action.InertiaJump);
         }
 
         // 慣性ジャンプ 強制中止
-        private void StopInertiaJumpWhenSprintEnd()
+        private void StopInertiaJumpOnSprintEnd()
         {
             // 慣性ジャンプ中のみ
             if (!isDoingInertiaJump) return;
@@ -304,12 +307,28 @@ namespace MyScripts.Runtime
 
             // 慣性ジャンプによる速度増加を打ち消す
 
-            Vector2 cancelHorizontalVelocity = appliedHorizontalOuterVelocityWhenInertiaJumpBeganLast *
-                                               horizontalVelocityTotalAttenuatedRateSinceInertiaJumpBegan;
-            ApplyOuterVelocity(new Vector3(-cancelHorizontalVelocity.x, 0.0f, -cancelHorizontalVelocity.y));
+            // 慣性ジャンプ開始時からの速度変化率
+            // 減衰量を算出したいので、0~1に制限する
+            Vector2 horizontalVelocityAttenuation =
+                nativeHorizontalVelocity / nativeHorizontalVelocityWhenInertiaJumpBeganLast;
+            float verticalVelocityAttenuation = verticalVelocity / verticalVelocityWhenInertiaJumpBeganLast;
+            horizontalVelocityAttenuation.x = Mathf.Clamp01(horizontalVelocityAttenuation.x);
+            horizontalVelocityAttenuation.y = Mathf.Clamp01(horizontalVelocityAttenuation.y);
+            verticalVelocityAttenuation = Mathf.Clamp01(verticalVelocityAttenuation);
 
-            appliedHorizontalOuterVelocityWhenInertiaJumpBeganLast = Vector2.zero;
-            horizontalVelocityTotalAttenuatedRateSinceInertiaJumpBegan = 0.0f;
+            // その減衰量に基づいて、慣性ジャンプ開始時に加えた速度を減衰させ、
+            // それを打ち消す速度を加える
+            Vector3 cancelVelocity = new Vector3(
+                appliedOuterVelocityWhenInertiaJumpBeganLast.x * horizontalVelocityAttenuation.x,
+                appliedOuterVelocityWhenInertiaJumpBeganLast.y * verticalVelocityAttenuation,
+                appliedOuterVelocityWhenInertiaJumpBeganLast.z * horizontalVelocityAttenuation.y
+            );
+            ApplyOuterVelocity(-cancelVelocity);
+
+            // 一応、記録した値をリセットしておく
+            appliedOuterVelocityWhenInertiaJumpBeganLast = Vector3.zero;
+            nativeHorizontalVelocityWhenInertiaJumpBeganLast = Vector2.zero;
+            verticalVelocityWhenInertiaJumpBeganLast = 0.0f;
 
             isDoingInertiaJump = false;
         }
@@ -345,8 +364,6 @@ namespace MyScripts.Runtime
             // attenuate the native velocity
             if (nativeHorizontalVelocity != Vector2.zero)
             {
-                Vector2 originalNativeHorizontalVelocity = nativeHorizontalVelocity;
-
                 float attenuationRate = isGrounded
                     ? param.NativeHorizontalVelocityAttenuationRateOnGround
                     : param.NativeHorizontalVelocityAttenuationRateInAir;
@@ -355,14 +372,6 @@ namespace MyScripts.Runtime
                 if (nativeHorizontalVelocity.sqrMagnitude < 1e-4f)
                 {
                     nativeHorizontalVelocity = Vector2.zero;
-                }
-
-                // update total attenuation record
-                if (horizontalVelocityTotalAttenuatedRateSinceInertiaJumpBegan > 0.0f)
-                {
-                    float attenuatedRate =
-                        nativeHorizontalVelocity.magnitude / originalNativeHorizontalVelocity.magnitude;
-                    horizontalVelocityTotalAttenuatedRateSinceInertiaJumpBegan *= attenuatedRate;
                 }
             }
         }

--- a/Assets/_MyAssets/Scripts/Runtime/PlayerController.cs
+++ b/Assets/_MyAssets/Scripts/Runtime/PlayerController.cs
@@ -231,16 +231,14 @@ namespace MyScripts.Runtime
             if (hasBecameNotGroundedThisFrame)
                 becameNotGroundedPosition = transform.position;
 
-            // 地面に着地したら、少しだけ(クールタイム)待ってから、再度慣性ジャンプを行えるようにする
-            if (isGrounded && isDoingInertiaJump && !onInertiaJumpCt)
+            // 地面に着地したら、慣性ジャンプ終了
+            if (isGrounded)
             {
-                onInertiaJumpCt = true;
-
-                param.InertiaJumpCoolTime.SecAwaitThenDo(() =>
+                if (isDoingInertiaJump)
                 {
                     isDoingInertiaJump = false;
-                    onInertiaJumpCt = false;
-                }, ct: destroyCancellationToken).Forget();
+                    BeginInertiaCooldownCountAsync(destroyCancellationToken).Forget();
+                }
             }
         }
 
@@ -258,6 +256,9 @@ namespace MyScripts.Runtime
 
             // ジャンプ中ならダメ
             if (isJumping) return;
+
+            // クールタイム中ならダメ
+            if (onInertiaJumpCt) return;
 
             // 慣性ジャンプ中ならダメ
             if (isDoingInertiaJump) return;
@@ -305,7 +306,7 @@ namespace MyScripts.Runtime
             // ダッシュしていないなら
             if (isSprinting) return;
 
-            // 慣性ジャンプによる速度増加を打ち消す
+            // 慣性ジャンプを終了する. また、開始時の速度増加を打ち消す
 
             // 慣性ジャンプ開始時からの速度変化率
             // 減衰量を算出したいので、0~1に制限する
@@ -330,7 +331,9 @@ namespace MyScripts.Runtime
             nativeHorizontalVelocityWhenInertiaJumpBeganLast = Vector2.zero;
             verticalVelocityWhenInertiaJumpBeganLast = 0.0f;
 
+            // 慣性ジャンプ終了
             isDoingInertiaJump = false;
+            BeginInertiaCooldownCountAsync(destroyCancellationToken).Forget();
         }
 
         private void CameraRotation()
@@ -719,6 +722,20 @@ namespace MyScripts.Runtime
                 height = 0.0f;
                 return false;
             }
+        }
+
+        // 慣性ジャンプのクールタイムフラグを立て、一定時間経過後に戻す
+        private async UniTask BeginInertiaCooldownCountAsync(Ct ct)
+        {
+            if (onInertiaJumpCt)
+            {
+                "既にクールタイムをカウント中です".Print(LogSettings.Warning);
+                return;
+            }
+
+            onInertiaJumpCt = true;
+            await param.InertiaJumpCoolTime.SecAwait(ct: ct);
+            onInertiaJumpCt = false;
         }
 
         private static bool IsInsideOfAnyBorder(IReadOnlyList<Border> borders, Vector3 position, byte targetLayer)


### PR DESCRIPTION
## 概要

慣性ジャンプの条件を調整したが、それでも暴発するケースはありそうだったので、
タイトルの通りの仕様を入れてみる

### 条件を調整した Issue, PR
- [【新規実装】慣性ジャンプ要らない説 #325](https://github.com/foriver4725/Qualia/issues/325)
- [慣性ジャンプの発動条件に、目の前が崖であることを追加#329](https://github.com/foriver4725/Qualia/pull/329)

## 補足情報

個人的に、結構好感触

## プレイ動画

https://github.com/user-attachments/assets/a736c2f6-d8d2-41a8-bf1e-4a2cefd00e44
