### PR TITLE
雨shaderの修正

### DIFF
--- a/Assets/_MyAssets/Scripts/Runtime/Rain.cs
+++ b/Assets/_MyAssets/Scripts/Runtime/Rain.cs
@@ -16,7 +16,6 @@
         private static readonly int MoveTotal_ID = Shader.PropertyToID("_MoveTotal");
         private static readonly int Move_ID = Shader.PropertyToID("_Move");
         private static readonly int TargetPosition_ID = Shader.PropertyToID("_TargetPosition");
-        private static readonly int PrevInvMatrix_ID = Shader.PropertyToID("_PrevInvMatrix");
 
         private new Renderer renderer;
 
@@ -25,7 +24,6 @@
         private Color[] colors;
         private Vector2[] uvs;
         private float move = 0f;
-        private Matrix4x4 viewMatrixPrev;
 
         private void Awake()
         {
@@ -78,8 +76,6 @@
             meshFilter.sharedMesh = mesh;
             meshFilter.sharedMesh.SetIndices(indices, MeshTopology.Lines, 0);
 
-            viewMatrixPrev = playerCamera.worldToCameraMatrix;
-
             renderer.material.SetFloat(Range_ID, Range);
             renderer.material.SetFloat(RangeR_ID, RangeR);
             renderer.material.SetFloat(Move_ID, Speed);
@@ -92,10 +88,8 @@
 
             renderer.material.SetFloat(MoveTotal_ID, move);
             renderer.material.SetVector(TargetPosition_ID, target_position);
-            renderer.material.SetMatrix(PrevInvMatrix_ID, viewMatrixPrev * playerCamera.cameraToWorldMatrix);
 
             move = Mathf.Repeat(move + Speed, Range * 2f);
-            viewMatrixPrev = playerCamera.worldToCameraMatrix;
         }
     }
 }

--- a/Assets/_MyAssets/Scripts/Runtime/Rain.cs
+++ b/Assets/_MyAssets/Scripts/Runtime/Rain.cs
@@ -3,8 +3,6 @@
     [RequireComponent(typeof(MeshFilter), typeof(MeshRenderer))]
     internal sealed class Rain : MonoBehaviour
     {
-        [SerializeField] private Camera playerCamera;
-
         private const int MaxPoint = 4096;
         private const float Speed = -1f;
 

--- a/Assets/_MyAssets/Shaders/Raindrop/Raindrop.shader
+++ b/Assets/_MyAssets/Shaders/Raindrop/Raindrop.shader
@@ -50,7 +50,6 @@
             };
 
             CBUFFER_START(UnityPerMaterial)
-                float4x4 _PrevInvMatrix;
                 float3   _TargetPosition;
                 float    _Range;
                 float    _RangeR;
@@ -64,7 +63,7 @@
                 float3 posOS = v.positionOS;
                 posOS.y += _MoveTotal;
 
-                float3 target = _TargetPosition; // C#でワールド渡しなら、OSに変換するか target をWSで合わせるのじゃ！
+                float3 target = _TargetPosition;
                 float3 trip = floor(((target - posOS) * _RangeR + 1) * 0.5);
                 trip *= (_Range * 2.0);
                 posOS += trip;
@@ -73,19 +72,10 @@
                 float4 headOS = float4(posOS, 1.0) * v.uv.x;
                 float4 tv0CS  = TransformObjectToHClip(headOS.xyz);
 
-                // trail（前フレームView相当）
+                // trail（カメラ方向に影響されない固定オフセット）
                 posOS.y -= _Move;
                 float4 trailOS = float4(posOS, 1.0) * v.uv.y;
-
-                // 現フレーム Object->View
-                float3 posWS = TransformObjectToWorld(trailOS.xyz);
-                float4 tv1VS = mul(GetWorldToViewMatrix(), float4(posWS, 1.0));
-
-                // 前フレーム系への変換（元の流れ：MV -> PrevInv -> P）
-                float4 tv1VS_prev = mul(_PrevInvMatrix, tv1VS);
-
-                // View -> Clip（HDRPのプロジェクション行列）
-                float4 tv1CS = mul(GetViewToHClipMatrix(), tv1VS_prev);
+                float4 tv1CS   = TransformObjectToHClip(trailOS.xyz);
 
                 Varyings o;
                 o.positionCS = tv0CS + tv1CS;


### PR DESCRIPTION
## 概要
カメラの移動・回転方向に雨粒が引き伸ばされて変形していた問題を修正した。

## 行ったこと
- **`Raindrop.shader` を修正**
  - trail 頂点の変換を `GetWorldToViewMatrix() → _PrevInvMatrix → GetViewToHClipMatrix()` から `TransformObjectToHClip()` に置き換え
  - `_PrevInvMatrix`（`float4x4`）を CBUFFER から削除
- **`Rain.cs` を修正**
  - `_PrevInvMatrix` のシェーダープロパティ ID（`PrevInvMatrix_ID`）を削除
  - 前フレームのView行列を保持していた `viewMatrixPrev` フィールドを削除
  - `Update()` 内の `SetMatrix(PrevInvMatrix_ID, ...)` および `viewMatrixPrev` 更新処理を削除

## 行わなかったこと
- 雨粒のサイズ・速度・密度など、変形以外のパラメータ調整
- `MeshTopology.Lines` から三角形ポリゴンへの変更など、メッシュ構造の見直し

## 補足情報
- 変形の原因は `_PrevInvMatrix`（前後フレームの View 行列差分）を trail 頂点に適用していたこと。カメラが動くと head と trail のクリップ空間座標がずれ、雨粒がカメラの移動方向に引き伸ばされていた
- シェーダー変更後、マテリアルの内部プロパティオフセットが古い CBUFFER レイアウトと一致しなくなるため、該当マテリアルを Inspector で選択し直して再保存が必要（`Property offset falls outside of range` エラーへの対処）

## プレイ動画（可能ならば）
<img width="400" height="200" alt="Videotogif (13)" src="https://github.com/user-attachments/assets/f67e3be3-7820-4ea8-8fa7-4165c58f062c" />
