### PR TITLE
進捗状況に応じたストーリー動画を再生するよう修正

### DIFF
--- a/Assets/_MyAssets/Scenes/Main.unity
+++ b/Assets/_MyAssets/Scenes/Main.unity
@@ -2478,6 +2478,7 @@ MonoBehaviour:
   sosSignRatioUIManager: {fileID: 885902798}
   soundPlayer: {fileID: 195949041}
   sosAnimaArrangementSeedLabel: {fileID: 1661366117749799019}
+  storyMovie: {fileID: 11400000, guid: a3c3ad9930d7e894cb66aa5d272f446b, type: 2}
 --- !u!1 &670357120
 GameObject:
   m_ObjectHideFlags: 0
@@ -2527,7 +2528,8 @@ MonoBehaviour:
   - {fileID: 21300000, guid: f2fcae06477339a4c92004476d4a4c87, type: 3}
   - {fileID: 21300000, guid: fc0394e59f2de0740b7ca7bf5557f0fa, type: 3}
   - {fileID: 21300000, guid: 78ad3802a0854514e98974a55583e5a6, type: 3}
-  durationUntilPlay: 0.5
+  durationUntilStoryMovie: 0.5
+  durationUntilTutorialImages: 1
   playOptions:
     isAutoStepEnabled: 1
     isManualSkipEnabled: 1

--- a/Assets/_MyAssets/Scripts/Runtime/CutScenePlayer.cs
+++ b/Assets/_MyAssets/Scripts/Runtime/CutScenePlayer.cs
@@ -47,6 +47,12 @@ namespace MyScripts.Runtime
                 return;
             }
 
+            if (videoClip == null)
+            {
+                "VideoClip が設定されていません。".Print(LogSettings.Error);
+                return;
+            }
+
             IsPlaying = true;
 
             // フェードイン中に呼び出し元がキャンセルした場合、フェードインを止めてからフェードアウトへ移行するため

--- a/Assets/_MyAssets/Scripts/Runtime/SOSSignFindManager.cs
+++ b/Assets/_MyAssets/Scripts/Runtime/SOSSignFindManager.cs
@@ -32,6 +32,10 @@ namespace MyScripts.Runtime
         private bool hasPlayed66Movie;
         private bool hasPlayed100Movie;
 
+        // マイルストーン判定に使う達成率の閾値
+        private const float Ratio33 = 1.0f / 3.0f;
+        private const float Ratio66 = 2.0f / 3.0f;
+
         #region Interface Implementation
 
         public void GetDataAndUpdateMyProperties()
@@ -99,22 +103,26 @@ namespace MyScripts.Runtime
 
             GetDataAndUpdateMyProperties();
 
+            // removedSOSSignCount が確定した直後にフラグを初期化する
+            // ロード再開時に既に超えていたマイルストーンは再生しない
+            {
+                float initialRatio = 1.0f * removedSOSSignCount / Constants.SOSSignCount;
+                hasPlayed33Movie  = initialRatio >= Ratio33;
+                hasPlayed66Movie  = initialRatio >= Ratio66;
+                hasPlayed100Movie = initialRatio >= 1.0f;
+            }
+
             Setup(sosSigns);
         }
 
         private void Start()
         {
-            // メソッドのコメントに従って、
+            // UpdateRatio() のコメントに従って、
             // - Awake() より後に呼び出す
             // - changeFillSmoothly は false にする
-            float initialRatio = 1.0f * removedSOSSignCount / Constants.SOSSignCount;
-
-            // ロード再開時に既に超えていたマイルストーンは再生しない
-            hasPlayed33Movie  = initialRatio >= 1.0f / 3.0f;
-            hasPlayed66Movie  = initialRatio >= 2.0f / 3.0f;
-            hasPlayed100Movie = initialRatio >= 1.0f;
-
-            sosSignRatioUIManager.UpdateRatio(initialRatio, changeFillSmoothly: false);
+            sosSignRatioUIManager.UpdateRatio(
+                1.0f * removedSOSSignCount / Constants.SOSSignCount,
+                changeFillSmoothly: false);
         }
 
         // SOSサインを取得する
@@ -198,27 +206,42 @@ namespace MyScripts.Runtime
         // Start() でセーブデータから初期フラグを設定しているため、ロード再開時の誤再生は起きない
         private void TryPlayMilestoneMovie()
         {
+            if (storyMovie == null)
+            {
+                "SStoryMovie が設定されていません。".Print(LogSettings.Error);
+                return;
+            }
+
             float ratio = 1.0f * removedSOSSignCount / Constants.SOSSignCount;
 
+            // 今回到達したマイルストーンを特定する
             SStoryMovie.GameProgress? progress = null;
-            if (!hasPlayed33Movie && ratio >= 1.0f / 3.0f)
-            {
-                hasPlayed33Movie = true;
+            if (!hasPlayed33Movie && ratio >= Ratio33)
                 progress = SStoryMovie.GameProgress.P33;
-            }
-            else if (!hasPlayed66Movie && ratio >= 2.0f / 3.0f)
-            {
-                hasPlayed66Movie = true;
+            else if (!hasPlayed66Movie && ratio >= Ratio66)
                 progress = SStoryMovie.GameProgress.P66;
-            }
             else if (!hasPlayed100Movie && ratio >= 1.0f)
-            {
-                hasPlayed100Movie = true;
                 progress = SStoryMovie.GameProgress.P100;
+
+            if (!progress.HasValue) return;
+
+            // クリップを取得してから null チェックし、有効な場合のみフラグを立てて再生する
+            // フラグを先に立てると、クリップ未設定のマイルストーンが以後永久に再生不能になるため
+            VideoClip clip = storyMovie.Get(progress.Value);
+            if (clip == null)
+            {
+                $"マイルストーン {progress.Value} の VideoClip が設定されていません。".Print(LogSettings.Error);
+                return;
             }
 
-            if (progress.HasValue)
-                CutScenePlayer.Instance.PlayAsync(storyMovie.Get(progress.Value), destroyCancellationToken).Forget();
+            switch (progress.Value)
+            {
+                case SStoryMovie.GameProgress.P33:  hasPlayed33Movie  = true; break;
+                case SStoryMovie.GameProgress.P66:  hasPlayed66Movie  = true; break;
+                case SStoryMovie.GameProgress.P100: hasPlayed100Movie = true; break;
+            }
+
+            CutScenePlayer.Instance.PlayAsync(clip, destroyCancellationToken).Forget();
         }
 
         // Click したなら true を、 Exit したなら false を返す

--- a/Assets/_MyAssets/Scripts/Runtime/SOSSignFindManager.cs
+++ b/Assets/_MyAssets/Scripts/Runtime/SOSSignFindManager.cs
@@ -1,6 +1,7 @@
 ﻿using MyScripts.Common.SaveSystem;
 using MyScripts.Runtime.Log;
 using MyScripts.Runtime.UI.Main;
+using UnityEngine.Video;
 
 namespace MyScripts.Runtime
 {
@@ -17,12 +18,19 @@ namespace MyScripts.Runtime
         [SerializeField] private SOSSignRatioUIManager sosSignRatioUIManager;
         [SerializeField] private SOSSoundPlayer soundPlayer;
         [SerializeField] private TextMeshProUGUI sosAnimaArrangementSeedLabel;
+        [SerializeField] private SStoryMovie storyMovie;
 
         // Awake で初期化
         private SSOSSignLogText sosSignLogText;
         private int sosSignCountReal;
         private int removedSOSSignCount = -1;
         private Collider[] sosSigns; // コライダーはルートに付いている
+
+        // セーブデータから復元した初期達成率をもとに Start() で初期化する
+        // ロード再開時に既に超えたマイルストーンを再生しないためのフラグ
+        private bool hasPlayed33Movie;
+        private bool hasPlayed66Movie;
+        private bool hasPlayed100Movie;
 
         #region Interface Implementation
 
@@ -99,8 +107,14 @@ namespace MyScripts.Runtime
             // メソッドのコメントに従って、
             // - Awake() より後に呼び出す
             // - changeFillSmoothly は false にする
-            sosSignRatioUIManager.UpdateRatio(1.0f * removedSOSSignCount / Constants.SOSSignCount,
-                changeFillSmoothly: false);
+            float initialRatio = 1.0f * removedSOSSignCount / Constants.SOSSignCount;
+
+            // ロード再開時に既に超えていたマイルストーンは再生しない
+            hasPlayed33Movie  = initialRatio >= 1.0f / 3.0f;
+            hasPlayed66Movie  = initialRatio >= 2.0f / 3.0f;
+            hasPlayed100Movie = initialRatio >= 1.0f;
+
+            sosSignRatioUIManager.UpdateRatio(initialRatio, changeFillSmoothly: false);
         }
 
         // SOSサインを取得する
@@ -145,6 +159,7 @@ namespace MyScripts.Runtime
                                     sosSignLogText.GetRandom(SSOSSignLogText.LogType.OnRemoveWithAnima));
 
                                 soundPlayer.LetPlay(SSOSSound.Situation.CouldRemove);
+                                TryPlayMilestoneMovie();
                             }
                             else
                             {
@@ -177,6 +192,33 @@ namespace MyScripts.Runtime
                     })
                     .AddTo(collider);
             }
+        }
+
+        // 現在の達成率に応じて未再生のマイルストーン動画を再生する
+        // Start() でセーブデータから初期フラグを設定しているため、ロード再開時の誤再生は起きない
+        private void TryPlayMilestoneMovie()
+        {
+            float ratio = 1.0f * removedSOSSignCount / Constants.SOSSignCount;
+
+            SStoryMovie.GameProgress? progress = null;
+            if (!hasPlayed33Movie && ratio >= 1.0f / 3.0f)
+            {
+                hasPlayed33Movie = true;
+                progress = SStoryMovie.GameProgress.P33;
+            }
+            else if (!hasPlayed66Movie && ratio >= 2.0f / 3.0f)
+            {
+                hasPlayed66Movie = true;
+                progress = SStoryMovie.GameProgress.P66;
+            }
+            else if (!hasPlayed100Movie && ratio >= 1.0f)
+            {
+                hasPlayed100Movie = true;
+                progress = SStoryMovie.GameProgress.P100;
+            }
+
+            if (progress.HasValue)
+                CutScenePlayer.Instance.PlayAsync(storyMovie.Get(progress.Value), destroyCancellationToken).Forget();
         }
 
         // Click したなら true を、 Exit したなら false を返す


### PR DESCRIPTION
## 概要
カットシーン動画の管理を ScriptableObject（`SStoryMovie`）に一元化し、`CutScenePlayer` を VideoClip を保持しない共通再生基盤に変更した。
ゲーム開始直後・33%/66%/100% 達成時点の4タイミングで対応する動画が自動再生されるよう対応した。

## 行ったこと
- **`SStoryMovie.cs` を新規作成**（`SO/Movie/Story Movie` メニューから生成可能）
  - `P0`（ゲーム開始）/ `P33` / `P66` / `P100`（エンディング）の4つの `VideoClip` フィールドを持つ SO
  - `Get(GameProgress)` メソッドで進行状況に対応するクリップを取得できる設計
- **`CutScenePlayer.cs` を修正**
  - `[SerializeField] VideoClip videoClip` フィールドを削除し、`PlayAsync(VideoClip clip, Ct ct)` として呼び出し元から渡す方式に変更
  - `clip == null` の場合は即 `return` するガードを追加
- **`IntroPlayer.cs` を修正**
  - `[SerializeField] SStoryMovie storyMovie` を追加
  - ゲーム開始直後に `storyMovie.Get(GameProgress.P0)` の動画を再生し、完了後にチュートリアル画像シーケンスを再生するよう変更
- **`SOSSignFindManager.cs` を修正**
  - `[SerializeField] SStoryMovie storyMovie` を追加
  - `hasPlayed33Movie` / `hasPlayed66Movie` / `hasPlayed100Movie` フラグを追加
  - `Start()` でセーブデータの初期達成率からフラグを初期化（ロード再開時の誤再生防止）
  - SOS サイン除去後に `TryPlayMilestoneMovie()` を呼び出すよう変更
  - `TryPlayMilestoneMovie()` — 33%/66%/100% を初めて超えた時に対応動画を再生

## 行わなかったこと
- 動画再生中のスキップ機能（`ImageSequencePlayer` が持つような手動スキップ）
- 達成率フラグのセーブデータへの永続化（現状はセッション内メモリ管理のみ。ロード再開時は `removedSOSSignCount` から再計算して対応）
- 100% 達成後のエンディング遷移処理（動画再生後のシーン移動等）

## 補足情報
- `CutScenePlayer` は VideoClip を一切保持しなくなったため、同一インスタンスで複数の動画を順に再生し分けることができる
- ロード再開時の誤再生は `Start()` でのフラグ初期化で防止している。例: 40% で再開した場合、`hasPlayed33Movie = true` に初期化されるため 33% 動画は再生されない
- **Unity Editor での作業**: `SOSSignFindManager` と `IntroPlayer` の `Story Movie` フィールドに `_StoryMovie` アセットをアサインし、各 `VideoClip` フィールドに動画ファイルを設定する必要がある

## プレイ動画（可能ならば）
<img width="400" height="200" alt="Videotogif (14)" src="https://github.com/user-attachments/assets/24f936d5-3c98-4aa0-b940-89fd9a3013f7" />


<img width="400" height="200" alt="Videotogif (15)" src="https://github.com/user-attachments/assets/257a4d95-3656-4820-976e-113f6c2704d6" />

