### PR TITLE
アニマを上書きする時、最初の離脱処理を行わないようにした

### DIFF
--- a/Assets/_MyAssets/Scripts/Runtime/AnimalLeaveInvoker.cs
+++ b/Assets/_MyAssets/Scripts/Runtime/AnimalLeaveInvoker.cs
@@ -83,13 +83,16 @@ namespace MyScripts.Runtime
         {
             var type = character.CharacterType;
 
-            // 同スロットに既存キャラがあれば、何もしなくて良い
-            if (possessingCharacters[type] == null)
+            // 同スロットに既存アニマがあるなら、それを元に戻してから上書き取得する
+            if (possessingCharacters[type] != null)
             {
-                possessingCharacters[type] = character;
-                possessingCharacters[type].SetVisible(false);
-                possessingCharacters[type].Collider.enabled = false;
+                possessingCharacters[type].SetVisible(true);
+                possessingCharacters[type].Collider.enabled = true;
             }
+
+            possessingCharacters[type] = character;
+            possessingCharacters[type].SetVisible(false);
+            possessingCharacters[type].Collider.enabled = false;
 
             // 陸のアニマなら、陸のSOSサインを表示させる
             if (type == CharacterType.Land)
@@ -136,7 +139,14 @@ namespace MyScripts.Runtime
                 return;
             }
 
-            LeaveCharacterInternal(type);
+            possessingCharacters[type].SetVisible(true);
+            possessingCharacters[type].Collider.enabled = true;
+            possessingCharacters[type] = null;
+
+            // 陸のアニマなら、陸のSOSサインを非表示にする
+            if (type == CharacterType.Land)
+                foreach (var sosSign in landSOSSigns)
+                    sosSign.TrySetActiveSmokeOnlyWhenLand(false);
 
             // タイマー満了時など、CTS が残っている場合は解放する
             possessTimerCtses[type]?.Cancel();
@@ -160,22 +170,6 @@ namespace MyScripts.Runtime
         }
 
         // ======== private helpers ========
-
-        // UI 更新なし・サウンドなしでスロットを解放する内部処理
-        private void LeaveCharacterInternal(CharacterType type)
-        {
-            var character = possessingCharacters[type];
-            if (character == null) return;
-
-            // 陸のアニマなら、陸のSOSサインを非表示にする
-            if (type == CharacterType.Land)
-                foreach (var sosSign in landSOSSigns)
-                    sosSign.TrySetActiveSmokeOnlyWhenLand(false);
-
-            character.SetVisible(true);
-            character.Collider.enabled = true;
-            possessingCharacters[type] = null;
-        }
 
         // displayOrder の現在順に従いスロット0〜2を一括更新
         // タイマー満了・新規取得・上書き取得いずれのタイミングでも必ず呼ぶ

--- a/Assets/_MyAssets/Scripts/Runtime/AnimalLeaveInvoker.cs
+++ b/Assets/_MyAssets/Scripts/Runtime/AnimalLeaveInvoker.cs
@@ -83,15 +83,13 @@ namespace MyScripts.Runtime
         {
             var type = character.CharacterType;
 
-            // 同スロットに既存キャラがあれば内部解放（上書き取得）
-            if (possessingCharacters[type] != null)
+            // 同スロットに既存キャラがあれば、何もしなくて良い
+            if (possessingCharacters[type] == null)
             {
-                LeaveCharacterInternal(type);
+                possessingCharacters[type] = character;
+                possessingCharacters[type].SetVisible(false);
+                possessingCharacters[type].Collider.enabled = false;
             }
-
-            possessingCharacters[type] = character;
-            possessingCharacters[type].SetVisible(false);
-            possessingCharacters[type].Collider.enabled = false;
 
             // 陸のアニマなら、陸のSOSサインを表示させる
             if (type == CharacterType.Land)

--- a/Assets/_MyAssets/Scripts/Runtime/Character.cs
+++ b/Assets/_MyAssets/Scripts/Runtime/Character.cs
@@ -41,26 +41,16 @@ namespace MyScripts.Runtime
 
         #region Public Properties
 
-        internal Transform Transform => transform;
         internal Collider Collider => collider;
 
         internal CharacterType CharacterType => characterType;
-        internal MeshRenderer Container => container;
-        internal SpriteRenderer Icon => icon;
 
         internal Color MaterialColor => container.material.color;
 
-        internal bool SetVisible(bool isVisible)
+        internal void SetVisible(bool isVisible)
         {
             container.enabled = isVisible;
             icon.enabled = isVisible;
-            return isVisible;
-        }
-
-        internal void Teleport(Vector3 position, Vector3 forward)
-        {
-            transform.position = position;
-            transform.forward = forward;
         }
 
         #endregion

--- a/Assets/_MyAssets/Scripts/Runtime/SOSSign.cs
+++ b/Assets/_MyAssets/Scripts/Runtime/SOSSign.cs
@@ -7,8 +7,6 @@
         [SerializeField] private GameObject[] seaObjects;
         [SerializeField] private ParticleSystem smokeParticle;
 
-        [SerializeField] private new Collider collider;
-
         private void Awake()
         {
             if (characterType is CharacterType.None)

--- a/Assets/_MyAssets/Scripts/Runtime/SOSSign.cs
+++ b/Assets/_MyAssets/Scripts/Runtime/SOSSign.cs
@@ -9,8 +9,6 @@
 
         [SerializeField] private new Collider collider;
 
-        internal Collider Collider => collider;
-
         private void Awake()
         {
             if (characterType is CharacterType.None)


### PR DESCRIPTION
## 概要

陸のアニマを上書き取得するとき、煙が消えてから出てきてしまっていたので修正

https://github.com/user-attachments/assets/59da23e9-b0b8-46fb-bf68-065c937e13e2

