### PR TITLE
プレイヤーが入力できるようになった時の、1フレーム無効化するタイミングを修正

### DIFF
--- a/Assets/_MyAssets/Scripts/Common/InputManager.cs
+++ b/Assets/_MyAssets/Scripts/Common/InputManager.cs
@@ -154,6 +154,16 @@ namespace MyScripts.Common
 #endif
         }
 
+        internal static void MakePlayerControlAndInGameInputsDisabledUntilNextFrame()
+        {
+            PlayerControl.MakeJumpInputDisabledUntilNextFrame();
+            PlayerControl.MakeSprintInputDisabledUntilNextFrame();
+
+            InGame.MakeSubmitInputDisabledUntilNextFrame();
+            InGame.MakeCancelInputDisabledUntilNextFrame();
+            InGame.MakeEscapeInputDisabledUntilNextFrame();
+        }
+
         private sealed class MakeClickInputDisabledUntilNextFrameInfo
         {
             internal bool IsEnabled { get; private set; } = true;

--- a/Assets/_MyAssets/Scripts/Runtime/CutScenePlayer.cs
+++ b/Assets/_MyAssets/Scripts/Runtime/CutScenePlayer.cs
@@ -147,6 +147,7 @@ namespace MyScripts.Runtime
 
         private async UniTaskVoid OnEndPlayAsync(float duration, Ct ct)
         {
+            PauseInvoker.MakeInGameInputsDisabledUntilNextFrame();
             InputManager.EnableAllInputs();
 
             SetBgAlpha(bgAlphaMax);

--- a/Assets/_MyAssets/Scripts/Runtime/CutScenePlayer.cs
+++ b/Assets/_MyAssets/Scripts/Runtime/CutScenePlayer.cs
@@ -147,7 +147,7 @@ namespace MyScripts.Runtime
 
         private async UniTaskVoid OnEndPlayAsync(float duration, Ct ct)
         {
-            PauseInvoker.MakeInGameInputsDisabledUntilNextFrame();
+            InputManager.MakePlayerControlAndInGameInputsDisabledUntilNextFrame();
             InputManager.EnableAllInputs();
 
             SetBgAlpha(bgAlphaMax);

--- a/Assets/_MyAssets/Scripts/Runtime/ImageSequencePlayer.cs
+++ b/Assets/_MyAssets/Scripts/Runtime/ImageSequencePlayer.cs
@@ -159,7 +159,7 @@
 
         private async UniTaskVoid OnEndPlayAsync(TimeSpan bgFadeDuration, Ct ct)
         {
-            PauseInvoker.MakeInGameInputsDisabledUntilNextFrame();
+            InputManager.MakePlayerControlAndInGameInputsDisabledUntilNextFrame();
             InputManager.EnableAllInputs();
 
             SetAlpha(bg, bgAlphaMax);

--- a/Assets/_MyAssets/Scripts/Runtime/ImageSequencePlayer.cs
+++ b/Assets/_MyAssets/Scripts/Runtime/ImageSequencePlayer.cs
@@ -159,6 +159,7 @@
 
         private async UniTaskVoid OnEndPlayAsync(TimeSpan bgFadeDuration, Ct ct)
         {
+            PauseInvoker.MakeInGameInputsDisabledUntilNextFrame();
             InputManager.EnableAllInputs();
 
             SetAlpha(bg, bgAlphaMax);

--- a/Assets/_MyAssets/Scripts/Runtime/PauseInvoker.cs
+++ b/Assets/_MyAssets/Scripts/Runtime/PauseInvoker.cs
@@ -42,7 +42,7 @@ namespace MyScripts.Runtime
             if (!IsPaused) return false;
             IsPaused = false;
 
-            MakeInGameInputsDisabledUntilNextFrame();
+            InputManager.MakePlayerControlAndInGameInputsDisabledUntilNextFrame();
             InputManager.PlayerControl.Enabled = true;
             InputManager.InGame.Enabled = true;
 
@@ -50,15 +50,6 @@ namespace MyScripts.Runtime
             CursorAdjuster.SetCursorEnabled(false);
 
             return true;
-        }
-
-        internal static void MakeInGameInputsDisabledUntilNextFrame()
-        {
-            InputManager.PlayerControl.MakeJumpInputDisabledUntilNextFrame();
-            InputManager.PlayerControl.MakeSprintInputDisabledUntilNextFrame();
-            InputManager.InGame.MakeSubmitInputDisabledUntilNextFrame();
-            InputManager.InGame.MakeCancelInputDisabledUntilNextFrame();
-            InputManager.InGame.MakeEscapeInputDisabledUntilNextFrame();
         }
     }
 }

--- a/Assets/_MyAssets/Scripts/Runtime/PauseInvoker.cs
+++ b/Assets/_MyAssets/Scripts/Runtime/PauseInvoker.cs
@@ -42,6 +42,7 @@ namespace MyScripts.Runtime
             if (!IsPaused) return false;
             IsPaused = false;
 
+            MakeInGameInputsDisabledUntilNextFrame();
             InputManager.PlayerControl.Enabled = true;
             InputManager.InGame.Enabled = true;
 
@@ -49,6 +50,15 @@ namespace MyScripts.Runtime
             CursorAdjuster.SetCursorEnabled(false);
 
             return true;
+        }
+
+        internal static void MakeInGameInputsDisabledUntilNextFrame()
+        {
+            InputManager.PlayerControl.MakeJumpInputDisabledUntilNextFrame();
+            InputManager.PlayerControl.MakeSprintInputDisabledUntilNextFrame();
+            InputManager.InGame.MakeSubmitInputDisabledUntilNextFrame();
+            InputManager.InGame.MakeCancelInputDisabledUntilNextFrame();
+            InputManager.InGame.MakeEscapeInputDisabledUntilNextFrame();
         }
     }
 }

--- a/Assets/_MyAssets/Scripts/Runtime/UI/Main/Pause/ResumeButtonManager.cs
+++ b/Assets/_MyAssets/Scripts/Runtime/UI/Main/Pause/ResumeButtonManager.cs
@@ -20,13 +20,6 @@
         {
             base.OnClickSucceeded();
 
-            // インゲームの入力と干渉しないように、1フレームだけ無効化しておく.
-            InputManager.PlayerControl.MakeJumpInputDisabledUntilNextFrame();
-            InputManager.PlayerControl.MakeSprintInputDisabledUntilNextFrame();
-            InputManager.InGame.MakeSubmitInputDisabledUntilNextFrame();
-            InputManager.InGame.MakeCancelInputDisabledUntilNextFrame();
-            InputManager.InGame.MakeEscapeInputDisabledUntilNextFrame();
-
             _ = pauseInvoker.TryUnpause();
         }
     }


### PR DESCRIPTION
## 概要

### 以下のタイミングで、インゲームの入力を1フレーム無効化する
- ポーズ解除
- カットシーン再生終了
- 動画シーケンス再生終了
